### PR TITLE
Fixed broken contributors url

### DIFF
--- a/src/DE/asciidoc/golden-master/src/about-arc42.adoc
+++ b/src/DE/asciidoc/golden-master/src/about-arc42.adoc
@@ -18,4 +18,4 @@ Template Revision: 6.5 DE (asciidoc-basiert), Juni 2014
 We acknowledge that this document uses material from the
 arc 42 architecture template, http://www.arc42.de.
 Created by Dr. Peter Hruschka & Dr. Gernot Starke.
-For additional contributors see http://arc42.de/about/contributors.html
+For additional contributors see http://arc42.de/sonstiges/contributors.html

--- a/src/EN/asciidoc/golden-master/src/about-arc42.adoc
+++ b/src/EN/asciidoc/golden-master/src/about-arc42.adoc
@@ -18,4 +18,4 @@ Template Revision: 6.5 DE (asciidoc-basiert), Juni 2014
 We acknowledge that this document uses material from the
 arc 42 architecture template, http://www.arc42.de.
 Created by Dr. Peter Hruschka & Dr. Gernot Starke.
-For additional contributors see http://arc42.de/about/contributors.html
+For additional contributors see http://arc42.de/sonstiges/contributors.html


### PR DESCRIPTION
The contributors page has also a small bug, by the way (the blue header is missing, as its url points is relative, where it should be absolute: "/resources/arc42-site-banner-striped-blue.jpg") 
