### PR TITLE
suggestion to better differentiate betweeen "Requirements" and "Problem Statement"

### DIFF
--- a/EN/asciidoc/src/01_introduction_and_goals.adoc
+++ b/EN/asciidoc/src/01_introduction_and_goals.adoc
@@ -5,12 +5,14 @@
 ****
 Describes the relevant requirements and the driving forces that software architects and development team must consider. These include
 
-* underlying business goals, essential features and functional requirements for the system
+* underlying business objectives
+* essential tasks
+* essential features and functional requirements for the system
 * quality goals for the architecture
 * relevant stakeholders and their expectations
 ****
 
-=== Requirements Overview
+=== Problem Statement
 
 [role="arc42help"]
 ****


### PR DESCRIPTION
In the past, I always worked with the english version of the template and tried to reproduce the "Requirements" of the project in thsi chaper.
When saw the german version of the headline "Aufgabenstellung", I noticed that this better fits and more easily directs the architect to write the right content