### PR TITLE
do not use internal basebackend attribute

### DIFF
--- a/DE/asciidoc/arc42-template.adoc
+++ b/DE/asciidoc/arc42-template.adoc
@@ -8,7 +8,7 @@
 :toc-title: Inhaltsverzeichnis
 
 //additional style for arc42 help callouts
-ifdef::basebackend-html[]
+ifdef::backend-html5[]
 ++++
 <style>
 .arc42help {font-size:small; width: 14px; height: 16px; overflow: hidden; position: absolute; right: 0px; padding: 2px 0px 3px 2px;}
@@ -20,7 +20,7 @@ ifdef::basebackend-html[]
 }
 </style>
 ++++
-endif::basebackend-html[]
+endif::backend-html5[]
 
 // configure DE settings for asciidoc
 include::src/config.adoc[]

--- a/EN/asciidoc/arc42-template.adoc
+++ b/EN/asciidoc/arc42-template.adoc
@@ -8,7 +8,7 @@
 :toc-title: Table of Contents
 
 //additional style for arc42 help callouts
-ifdef::basebackend-html[]
+ifdef::backend-html5[]
 ++++
 <style>
 .arc42help {font-size:small; width: 14px; height: 16px; overflow: hidden; position: absolute; right: 0px; padding: 2px 0px 3px 2px;}
@@ -20,7 +20,7 @@ ifdef::basebackend-html[]
 }
 </style>
 ++++
-endif::basebackend-html[]
+endif::backend-html5[]
 
 // configure EN settings for asciidoc
 include::src/config.adoc[]

--- a/ES/asciidoc/arc42-template.adoc
+++ b/ES/asciidoc/arc42-template.adoc
@@ -8,7 +8,7 @@
 :toc-title: Contenido
 
 //Estilos adicionales para las llamadas de ayuda de arc42
-ifdef::basebackend-html[]
+ifdef::backend-html5[]
 ++++
 <style>
 .arc42help {font-size:small; width: 14px; height: 16px; overflow: hidden; position: absolute; right: 0px; padding: 2px 0px 3px 2px;}
@@ -20,7 +20,7 @@ ifdef::basebackend-html[]
 }
 </style>
 ++++
-endif::basebackend-html[]
+endif::backend-html5[]
 
 // Opciones de configuración en español (ES) para asciidoc
 include::src/config.adoc[]

--- a/RU/asciidoc/arc42-template.adoc
+++ b/RU/asciidoc/arc42-template.adoc
@@ -8,7 +8,7 @@
 :toc-title: Table of Contents
 
 //additional style for arc42 help callouts
-ifdef::basebackend-html[]
+ifdef::backend-html5[]
 ++++
 <style>
 .arc42help {font-size:small; width: 14px; height: 16px; overflow: hidden; position: absolute; right: 0px; padding: 2px 0px 3px 2px;}
@@ -20,7 +20,7 @@ ifdef::basebackend-html[]
 }
 </style>
 ++++
-endif::basebackend-html[]
+endif::backend-html5[]
 
 // configure EN settings for asciidoc
 include::src/config.adoc[]


### PR DESCRIPTION
The `basebackend` attribute for pdf is html, which is not whats intended here. So if you render this template to PDF it will show the following error:
```
asciidoctor: WARNING: conversion missing in backend pdf for pass
```

There are more details in this issue https://github.com/asciidoctor/asciidoctor/issues/2479