### PR TITLE
Add Dutch translation

### DIFF
--- a/NL/asciidoc/arc42-template.adoc
+++ b/NL/asciidoc/arc42-template.adoc
@@ -1,0 +1,96 @@
+// header file for arc42-template,
+// including all help texts
+//
+// ====================================
+
+= image:arc42-logo.png[arc42] Template
+// toc-title definition MUST follow document title without blank line!
+:toc-title: Inhoudsopgave
+
+//additional style for arc42 help callouts
+ifdef::backend-html5[]
+++++
+<style>
+.arc42help {font-size:small; width: 14px; height: 16px; overflow: hidden; position: absolute; right: 0; padding: 2px 0 3px 2px;}
+.arc42help::before {content: "?";}
+.arc42help:hover {width:auto; height: auto; z-index: 100; padding: 10px;}
+.arc42help:hover::before {content: "";}
+@media print {
+	.arc42help {display:none;}
+}
+</style>
+++++
+endif::backend-html5[]
+
+// configure EN settings for asciidoc
+include::src/config.adoc[]
+
+
+include::src/about-arc42.adoc[]
+
+// horizontal line
+***
+
+[role="arc42help"]
+****
+[NOTE]
+====
+Deze versie van de template bevat hulp en uitleg.
+Het is bedoel om bekend te raken met arc42 en om de concepten te begrijpen.
+Om uw eigen sytemen te documenteren adviseren we om de _kale_ versie te gebruiken.
+====
+****
+
+
+// numbering from here on
+:numbered:
+
+<<<<
+// 1. Introduction and Goals
+include::src/01_introduction_and_goals.adoc[]
+
+<<<<
+// 2. Architecture Constraints
+include::src/02_architecture_constraints.adoc[]
+
+<<<<
+// 3. System Scope and Context
+include::src/03_system_scope_and_context.adoc[]
+
+<<<<
+// 4. Solution Strategy
+include::src/04_solution_strategy.adoc[]
+
+<<<<
+// 5. Building Block View
+include::src/05_building_block_view.adoc[]
+
+<<<<
+// 6. Runtime View
+include::src/06_runtime_view.adoc[]
+
+<<<<
+// 7. Deployment View
+include::src/07_deployment_view.adoc[]
+
+<<<<
+// 8. Concepts
+include::src/08_concepts.adoc[]
+
+<<<<
+// 9. Architecture Decisions
+include::src/09_architecture_decisions.adoc[]
+
+<<<<
+// 10. Quality Requirements
+include::src/10_quality_requirements.adoc[]
+
+<<<<
+// 11. Technical Risks
+include::src/11_technical_risks.adoc[]
+
+<<<<
+// 12. Glossary
+include::src/12_glossary.adoc[]
+
+

--- a/NL/asciidoc/src/01_introduction_and_goals.adoc
+++ b/NL/asciidoc/src/01_introduction_and_goals.adoc
@@ -1,0 +1,137 @@
+[[section-introduction-and-goals]]
+== Introductie en Doelen
+
+[role="arc42help"]
+****
+Beschrijft de relevante requirements en het krachtenveld waar software architecten en het development team rekening mee moeten houden.
+Die bestaan onder ander uit
+
+// * underlying business goals,
+* het begrijpen van de achterliggende doelen van de business, 
+// * essential features, 
+* essentiele features,
+// * essential functional requirements, 
+* essentiele functionele requirements, 
+// * quality goals for the architecture and
+* kwaliteits doelen voor de architectuur en
+//* relevant stakeholders and their expectations
+* relevante belanghebbenden en hun verwachtingen
+****
+
+// === Requirements Overview
+=== Requirements Overzicht
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// Short description of the functional requirements, driving forces, extract (or abstract) of requirements.
+Korte beschrijven van de functionele requirements, drijvende krachten, uittreksel (of samenvatting) van de requirements.
+// Link to (hopefully existing) requirements documents (with version number and information where to find it).
+Verwijzing naar de (hopelijk bestaande) requirements documentatie (met versie nummer en informatie waar deze te vinden is).
+
+
+// .Motivation
+.Motivatie
+// From the point of view of the end users a system is created or modified to
+// improve support of a business activity and/or improve the quality.
+Vanuit het perspectief van de eind gebruikers is een systeem ontwikkeld of aangepast om een business activiteit beter te ondersteunen en/of om de kwaliteit van die activiteit te verbeteren.
+
+// .Form
+.Vorm
+// Short textual description, probably in tabular use-case format.
+Korte textuele beschrijving, mogelijk in use-case tabel formaat.
+// If requirements documents exist this overview should refer to these documents.
+Dit overzichts document moet naar het requirements document verwijzen (als dat bestaat).
+
+// Keep these excerpts as short as possible. Balance readability of this document with potential redundancy w.r.t to requirements documents.
+Houd deze uittreksels zo kort mogelijk. 
+Zoek een evenwicht tussen leesbaarheid van dit document en mogelijke dubbelingen met betrekking tot het requirements document.
+
+//.Further Information
+.Verdere Informatie
+
+// See https://docs.arc42.org/section-1/[Introduction and Goals] in the arc42 documentation.
+Zie https://docs.arc42.org/section-1/[Introductie en Doelen] in de arc42 documentatie.
+
+****
+
+// === Quality Goals
+=== Kwaliteits Doelen
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// The top three (max five) quality goals for the architecture whose fulfillment is of highest importance to the major stakeholders. 
+De top drie (max vijf) kwaliteits doelen aan de architectuur waarvan het behalen van het grootste belang is voor de primaire belanghebbenden.
+
+// We really mean quality goals for the architecture. Don't confuse them with project goals.
+// They are not necessarily identical.
+We bedoelen hier echt kwaliteits doelen voor de architectuur.
+Niet te verwarren met project doelen.
+
+// Consider this overview of potential topics (based upon the ISO 25010 standard):
+Overweeg dit overzicht met mogelijke onderwerpen (gebaseerd op de ISO 25010 standaard):
+
+// image::01_2_iso-25010-topics-EN.png["Categories of Quality Requirements"]
+image::01_2_iso-25010-topics-EN.png["Categorieen van mogelijke Kwaliteits Requirements"]
+
+// .Motivation
+.Motivatie
+// You should know the quality goals of your most important stakeholders, since they will influence fundamental architectural decisions. 
+Het is belangrijk de kwaliteits doelen van je belangrijkste belanghebbenden te kennen omdat deze invloed hebben op fundamentele architectuur keuzes.
+// Make sure to be very concrete about these qualities, avoid buzzwords.
+Denk eraan heel concreet te zijn over deze kwaliteiten, vermijd modewoorden.
+// If you as an architect do not know how the quality of your work will be judged...
+Alsof je als architect niet weet hoe de kwaliteit van je werk beoordeeld zal worden...
+
+// .Form
+.Vorm
+// A table with quality goals and concrete scenarios, ordered by priorities
+Een tabel met kwaliteits doelen en concrete scenarios, gesorteerd op prioriteit.
+****
+
+// === Stakeholders
+=== Belanghebbenden
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// Explicit overview of stakeholders of the system, i.e. all person, roles or organizations that
+Expliciet overzicht van belanghebbenden van het systeem, dat wil zeggen alle personen, rollen of oranisaties die
+
+// * should know the architecture
+* de architectuur moeten kennen
+// * have to be convinced of the architecture
+* van de architectuur overtuigd moeten worden
+// * have to work with the architecture or with code
+* met de architectuur of code moeten werken
+// * need the documentation of the architecture for their work
+* de documentatie van de architectuur nodig hebben voor hun werk
+// * have to come up with decisions about the system or its development
+* beslissingen moeten maken over het systeem of de ontwikkeling daarvan
+
+// .Motivation
+.Motivatie
+// You should know all parties involved in development of the system or affected by the system.
+Alle partijen die betrokken zijn bij de ontwikkeling of anderzinds geraakt worden door het systeem moeten bekend zijn.
+// Otherwise, you may get nasty surprises later in the development process.
+Anders kan dat later in het ontwikkelings proces tot nare verassingen zorgen.
+// These stakeholders determine the extent and the level of detail of your work and its results.
+Deze belanghebbenden bepalen in een grote mate de omvang en het detail niveau van de werkzaameheden en de resultaten.
+
+// .Form
+.Vorm
+// Table with role names, person names, and their expectations with respect to the architecture and its documentation.
+Tabel met de rollen, personen en hun verwachting met betrekking tot de architectuur en haar documentatie.
+****
+
+[options="header",cols="1,2,2"]
+|===
+// |Role/Name|Contact|Expectations
+|Rol/Naam|Contact persoon|Verwachtingen
+| _<Rol-1>_ | _<Contact-1>_ | _<Verwachting-1>_
+| _<Rol-2>_ | _<Contact-2>_ | _<Verwachting-2>_
+|===

--- a/NL/asciidoc/src/01_introduction_and_goals.adoc
+++ b/NL/asciidoc/src/01_introduction_and_goals.adoc
@@ -6,131 +6,85 @@
 Beschrijft de relevante requirements en het krachtenveld waar software architecten en het development team rekening mee moeten houden.
 Die bestaan onder ander uit
 
-// * underlying business goals,
 * het begrijpen van de achterliggende doelen van de business, 
-// * essential features, 
 * essentiele features,
-// * essential functional requirements, 
 * essentiele functionele requirements, 
-// * quality goals for the architecture and
 * kwaliteits doelen voor de architectuur en
-//* relevant stakeholders and their expectations
 * relevante belanghebbenden en hun verwachtingen
 ****
 
-// === Requirements Overview
 === Requirements Overzicht
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// Short description of the functional requirements, driving forces, extract (or abstract) of requirements.
 Korte beschrijven van de functionele requirements, drijvende krachten, uittreksel (of samenvatting) van de requirements.
-// Link to (hopefully existing) requirements documents (with version number and information where to find it).
 Verwijzing naar de (hopelijk bestaande) requirements documentatie (met versie nummer en informatie waar deze te vinden is).
 
 
-// .Motivation
 .Motivatie
-// From the point of view of the end users a system is created or modified to
-// improve support of a business activity and/or improve the quality.
 Vanuit het perspectief van de eind gebruikers is een systeem ontwikkeld of aangepast om een business activiteit beter te ondersteunen en/of om de kwaliteit van die activiteit te verbeteren.
 
-// .Form
 .Vorm
-// Short textual description, probably in tabular use-case format.
 Korte textuele beschrijving, mogelijk in use-case tabel formaat.
-// If requirements documents exist this overview should refer to these documents.
 Dit overzichts document moet naar het requirements document verwijzen (als dat bestaat).
 
-// Keep these excerpts as short as possible. Balance readability of this document with potential redundancy w.r.t to requirements documents.
 Houd deze uittreksels zo kort mogelijk. 
 Zoek een evenwicht tussen leesbaarheid van dit document en mogelijke dubbelingen met betrekking tot het requirements document.
 
-//.Further Information
 .Verdere Informatie
 
-// See https://docs.arc42.org/section-1/[Introduction and Goals] in the arc42 documentation.
 Zie https://docs.arc42.org/section-1/[Introductie en Doelen] in de arc42 documentatie.
 
 ****
 
-// === Quality Goals
 === Kwaliteits Doelen
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// The top three (max five) quality goals for the architecture whose fulfillment is of highest importance to the major stakeholders. 
 De top drie (max vijf) kwaliteits doelen aan de architectuur waarvan het behalen van het grootste belang is voor de primaire belanghebbenden.
 
-// We really mean quality goals for the architecture. Don't confuse them with project goals.
-// They are not necessarily identical.
 We bedoelen hier echt kwaliteits doelen voor de architectuur.
 Niet te verwarren met project doelen.
 
-// Consider this overview of potential topics (based upon the ISO 25010 standard):
 Overweeg dit overzicht met mogelijke onderwerpen (gebaseerd op de ISO 25010 standaard):
 
-// image::01_2_iso-25010-topics-EN.png["Categories of Quality Requirements"]
 image::01_2_iso-25010-topics-EN.png["Categorieen van mogelijke Kwaliteits Requirements"]
 
-// .Motivation
 .Motivatie
-// You should know the quality goals of your most important stakeholders, since they will influence fundamental architectural decisions. 
 Het is belangrijk de kwaliteits doelen van je belangrijkste belanghebbenden te kennen omdat deze invloed hebben op fundamentele architectuur keuzes.
-// Make sure to be very concrete about these qualities, avoid buzzwords.
 Denk eraan heel concreet te zijn over deze kwaliteiten, vermijd modewoorden.
-// If you as an architect do not know how the quality of your work will be judged...
 Alsof je als architect niet weet hoe de kwaliteit van je werk beoordeeld zal worden...
 
-// .Form
 .Vorm
-// A table with quality goals and concrete scenarios, ordered by priorities
 Een tabel met kwaliteits doelen en concrete scenarios, gesorteerd op prioriteit.
 ****
 
-// === Stakeholders
 === Belanghebbenden
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// Explicit overview of stakeholders of the system, i.e. all person, roles or organizations that
 Expliciet overzicht van belanghebbenden van het systeem, dat wil zeggen alle personen, rollen of oranisaties die
 
-// * should know the architecture
 * de architectuur moeten kennen
-// * have to be convinced of the architecture
 * van de architectuur overtuigd moeten worden
-// * have to work with the architecture or with code
 * met de architectuur of code moeten werken
-// * need the documentation of the architecture for their work
 * de documentatie van de architectuur nodig hebben voor hun werk
-// * have to come up with decisions about the system or its development
 * beslissingen moeten maken over het systeem of de ontwikkeling daarvan
 
-// .Motivation
 .Motivatie
-// You should know all parties involved in development of the system or affected by the system.
 Alle partijen die betrokken zijn bij de ontwikkeling of anderzinds geraakt worden door het systeem moeten bekend zijn.
-// Otherwise, you may get nasty surprises later in the development process.
 Anders kan dat later in het ontwikkelings proces tot nare verassingen zorgen.
-// These stakeholders determine the extent and the level of detail of your work and its results.
 Deze belanghebbenden bepalen in een grote mate de omvang en het detail niveau van de werkzaameheden en de resultaten.
 
-// .Form
 .Vorm
-// Table with role names, person names, and their expectations with respect to the architecture and its documentation.
 Tabel met de rollen, personen en hun verwachting met betrekking tot de architectuur en haar documentatie.
 ****
 
 [options="header",cols="1,2,2"]
 |===
-// |Role/Name|Contact|Expectations
 |Rol/Naam|Contact persoon|Verwachtingen
 | _<Rol-1>_ | _<Contact-1>_ | _<Verwachting-1>_
 | _<Rol-2>_ | _<Contact-2>_ | _<Verwachting-2>_

--- a/NL/asciidoc/src/02_architecture_constraints.adoc
+++ b/NL/asciidoc/src/02_architecture_constraints.adoc
@@ -1,0 +1,35 @@
+[[section-architecture-constraints]]
+// == Architecture Constraints
+== Architectuur Beperkingen
+
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// Any requirement that constraints software architects in their freedom of design and implementation decisions or decision about the development process. 
+Iedere requirement die de sofware architecten in hun vrijheid met betrekking tot ontwerp, implementatie of het ontwikkel proces beperken.  
+// These constraints sometimes go beyond individual systems and are valid for whole organizations and companies.
+Het kan zijn dat deze beperkingen verder gaan dan de individuele systemen en van toepassing zijn op hele organisaties of bedrijven.
+
+// .Motivation
+.Motivatie
+// Architects should know exactly where they are free in their design decisions and where they must adhere to constraints.
+Architecten moeten weten waar ze vrij zijn in de ontwerp keuzes en waar ze zich aan beperkingen moeten houden.
+// Constraints must always be dealt with; they may be negotiable, though.
+Beperkingen moeten altijd onder ogen worden gezien; echter, het kan zijn dat er over te onderhandelen valt.
+
+// .Form
+.Vorm
+// Simple tables of constraints with explanations.
+Simpele tabellen met beperkingen en bijbehorende uitleg.
+// If needed you can subdivide them into technical constraints, organizational and political constraints and conventions (e.g. programming or versioning guidelines, documentation or naming conventions)
+Zo nodig opgedeeld in technische, organisatorische en politieke beperkingen en conventies (bijv. programmeer of versionering guidelines, documentatie of naamgevings conventies).
+
+// .Further Information
+.Verdere Informatie
+
+// See https://docs.arc42.org/section-2/[Architecture Constraints] in the arc42 documentation.
+Zie https://docs.arc42.org/section-2/[Architectuur Beperkingen] in de arc42 documentatie.
+
+****

--- a/NL/asciidoc/src/02_architecture_constraints.adoc
+++ b/NL/asciidoc/src/02_architecture_constraints.adoc
@@ -1,35 +1,23 @@
 [[section-architecture-constraints]]
-// == Architecture Constraints
 == Architectuur Beperkingen
 
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// Any requirement that constraints software architects in their freedom of design and implementation decisions or decision about the development process. 
 Iedere requirement die de sofware architecten in hun vrijheid met betrekking tot ontwerp, implementatie of het ontwikkel proces beperken.  
-// These constraints sometimes go beyond individual systems and are valid for whole organizations and companies.
 Het kan zijn dat deze beperkingen verder gaan dan de individuele systemen en van toepassing zijn op hele organisaties of bedrijven.
 
-// .Motivation
 .Motivatie
-// Architects should know exactly where they are free in their design decisions and where they must adhere to constraints.
 Architecten moeten weten waar ze vrij zijn in de ontwerp keuzes en waar ze zich aan beperkingen moeten houden.
-// Constraints must always be dealt with; they may be negotiable, though.
 Beperkingen moeten altijd onder ogen worden gezien; echter, het kan zijn dat er over te onderhandelen valt.
 
-// .Form
 .Vorm
-// Simple tables of constraints with explanations.
 Simpele tabellen met beperkingen en bijbehorende uitleg.
-// If needed you can subdivide them into technical constraints, organizational and political constraints and conventions (e.g. programming or versioning guidelines, documentation or naming conventions)
 Zo nodig opgedeeld in technische, organisatorische en politieke beperkingen en conventies (bijv. programmeer of versionering guidelines, documentatie of naamgevings conventies).
 
-// .Further Information
 .Verdere Informatie
 
-// See https://docs.arc42.org/section-2/[Architecture Constraints] in the arc42 documentation.
 Zie https://docs.arc42.org/section-2/[Architectuur Beperkingen] in de arc42 documentatie.
 
 ****

--- a/NL/asciidoc/src/03_system_scope_and_context.adoc
+++ b/NL/asciidoc/src/03_system_scope_and_context.adoc
@@ -1,0 +1,114 @@
+[[section-system-scope-and-context]]
+// == System Scope and Context
+== Systeem Scope en Context
+
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// System scope and context - as the name suggests - delimits your system (i.e. your scope) from all its communication partners
+// (neighboring systems and users, i.e. the context of your system). It thereby specifies the external interfaces.
+De systeem scope en context maakt - zoals de naam suggereert - een onderscheid tussen het eigen systeem (d.w.z. de scope van het systeem dat wordt beschreven) en alle partners waarmee wordt gecommuniceerd (buur systemen en gebruikers, met andere woorden, de context van het systeem).
+Hiermee worden externe interfaces gedefineerd.
+
+// If necessary, differentiate the business context (domain specific inputs and outputs) from the technical context (channels, protocols, hardware).
+Maak, als het nodig is, onderscheid tussen business context (domein specifieke inputs en outputs) en technische context (kanalen, protocollen, hardware).
+
+// .Motivation
+.Motivatie
+// The domain interfaces and technical interfaces to communication partners are among your system's most critical aspects. 
+De domein en technische interfaces met communicatie partners horen bij meest kritieke aspecten van het systeem.
+// Make sure that you completely understand them.
+Wees er zeker van dat deze volledig te doorgronden.
+
+// .Form
+.Vorm
+// Various options:
+Verschillend opties:
+
+// * Context diagrams
+* Context diagrammen
+// * Lists of communication partners and their interfaces.
+* Lijst van communicatie partners en bijbehorende interfaces.
+
+
+// .Further Information
+.Verdere Informatie
+
+// See https://docs.arc42.org/section-3/[Context and Scope] in the arc42 documentation.
+Zie https://docs.arc42.org/section-3/[Context en Scope] in de arc42 documentatie.
+
+****
+
+
+//=== Business Context
+=== Business Context
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// Specification of *all* communication partners (users, IT-systems, ...) with explanations of domain specific inputs and outputs or interfaces.
+Specificatie van *alle* communicatie partners (gebruikers, IT-systemen, ...) met uitleg van domein specifieke inputs en outputs of interfaces.
+// Optionally you can add domain specific formats or communication protocols.
+Het is eventueel mogelijk om domein specifieke formaten of communicatie protocollen toe te voegen.
+
+// .Motivation
+.Motivatie
+// All stakeholders should understand which data are exchanged with the environment of the system.
+Alle belanghebbenden moeten begrijpen welke data er uitgewisseld wordt met de omgeving van het systeem.
+
+// .Form
+.Vorm
+// All kinds of diagrams that show the system as a black box and specify the domain interfaces to communication partners.
+Alle soorten diagrammen die het systeem als een black box weergeven en die de domein interfaces naar communicatie partners laten zien. 
+
+// Alternatively (or additionally) you can use a table.
+Een tabel vorm zou als alternatief (of toevoeging) gebruikt kunnen worden.
+// The title of the table is the name of your system, the three columns contain the name of the communication partner, the inputs, and the outputs.
+De naam van het systeem is de titel van de tabel.
+De drie kolommen bevatten de naam van de communicatie partner, de inputs en de outputs.
+
+****
+
+// **<Diagram or Table>**
+**<Diagram of Tabel>**
+
+// **<optionally: Explanation of external domain interfaces>**
+**<optioneel: Uitleg van de externe domein interfaces>**
+
+// === Technical Context
+=== Technische Context
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// Technical interfaces (channels and transmission media) linking your system to its environment. 
+Technische interfaces (kanalen en mechanismen) die het systeem met haar omgeving verbind.
+// In addition a mapping of domain specific input/output to the channels, i.e. an explanation with I/O uses which channel.
+Naast een mapping van domein specifieke input/output naar kanalen, dat wil zeggen, een uitleg welke I/O welke kanalen gebruikt.
+
+// .Motivation
+.Motivatie
+// Many stakeholders make architectural decision based on the technical interfaces between the system and its context.
+Veel belanghebbenden maken beslisisingen met betrekkeing tot de architectuur gebaseerd op de technische interfaces tussen het systeem en haar context.
+// Especially infrastructure or hardware designers decide these technical interfaces.
+Met name infrastructuur of hardware ontwerpers beslissen aan de hand van deze technische interfaces.
+
+// .Form
+.Vorm
+// E.g. UML deployment diagram describing channels to neighboring systems, together with a mapping table showing the relationships between channels and input/output.
+Bijvoorbeeld UML deployment diagrammen die de kanalen naar naburige systemen beschrijven, gecombineerd met mapping tabellen die de relatie tussen de kanalen en de input/output tonen.
+
+****
+
+// **<Diagram or Table>**
+**<Diagram of Tabel>**
+
+// **<optionally: Explanation of technical interfaces>**
+**<optioneel: Uitleg van technische interfaces>**
+
+// **<Mapping Input/Output to Channels>**
+**<Mapping Input/Output naar kanalen>**

--- a/NL/asciidoc/src/03_system_scope_and_context.adoc
+++ b/NL/asciidoc/src/03_system_scope_and_context.adoc
@@ -1,114 +1,76 @@
 [[section-system-scope-and-context]]
-// == System Scope and Context
 == Systeem Scope en Context
 
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// System scope and context - as the name suggests - delimits your system (i.e. your scope) from all its communication partners
-// (neighboring systems and users, i.e. the context of your system). It thereby specifies the external interfaces.
 De systeem scope en context maakt - zoals de naam suggereert - een onderscheid tussen het eigen systeem (d.w.z. de scope van het systeem dat wordt beschreven) en alle partners waarmee wordt gecommuniceerd (buur systemen en gebruikers, met andere woorden, de context van het systeem).
 Hiermee worden externe interfaces gedefineerd.
 
-// If necessary, differentiate the business context (domain specific inputs and outputs) from the technical context (channels, protocols, hardware).
 Maak, als het nodig is, onderscheid tussen business context (domein specifieke inputs en outputs) en technische context (kanalen, protocollen, hardware).
 
-// .Motivation
 .Motivatie
-// The domain interfaces and technical interfaces to communication partners are among your system's most critical aspects. 
 De domein en technische interfaces met communicatie partners horen bij meest kritieke aspecten van het systeem.
-// Make sure that you completely understand them.
 Wees er zeker van dat deze volledig te doorgronden.
 
-// .Form
 .Vorm
-// Various options:
 Verschillend opties:
 
-// * Context diagrams
 * Context diagrammen
-// * Lists of communication partners and their interfaces.
 * Lijst van communicatie partners en bijbehorende interfaces.
 
 
-// .Further Information
 .Verdere Informatie
 
-// See https://docs.arc42.org/section-3/[Context and Scope] in the arc42 documentation.
 Zie https://docs.arc42.org/section-3/[Context en Scope] in de arc42 documentatie.
 
 ****
 
 
-//=== Business Context
 === Business Context
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// Specification of *all* communication partners (users, IT-systems, ...) with explanations of domain specific inputs and outputs or interfaces.
 Specificatie van *alle* communicatie partners (gebruikers, IT-systemen, ...) met uitleg van domein specifieke inputs en outputs of interfaces.
-// Optionally you can add domain specific formats or communication protocols.
 Het is eventueel mogelijk om domein specifieke formaten of communicatie protocollen toe te voegen.
 
-// .Motivation
 .Motivatie
-// All stakeholders should understand which data are exchanged with the environment of the system.
 Alle belanghebbenden moeten begrijpen welke data er uitgewisseld wordt met de omgeving van het systeem.
 
-// .Form
 .Vorm
-// All kinds of diagrams that show the system as a black box and specify the domain interfaces to communication partners.
 Alle soorten diagrammen die het systeem als een black box weergeven en die de domein interfaces naar communicatie partners laten zien. 
 
-// Alternatively (or additionally) you can use a table.
 Een tabel vorm zou als alternatief (of toevoeging) gebruikt kunnen worden.
-// The title of the table is the name of your system, the three columns contain the name of the communication partner, the inputs, and the outputs.
 De naam van het systeem is de titel van de tabel.
 De drie kolommen bevatten de naam van de communicatie partner, de inputs en de outputs.
 
 ****
 
-// **<Diagram or Table>**
 **<Diagram of Tabel>**
 
-// **<optionally: Explanation of external domain interfaces>**
 **<optioneel: Uitleg van de externe domein interfaces>**
 
-// === Technical Context
 === Technische Context
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// Technical interfaces (channels and transmission media) linking your system to its environment. 
 Technische interfaces (kanalen en mechanismen) die het systeem met haar omgeving verbind.
-// In addition a mapping of domain specific input/output to the channels, i.e. an explanation with I/O uses which channel.
 Naast een mapping van domein specifieke input/output naar kanalen, dat wil zeggen, een uitleg welke I/O welke kanalen gebruikt.
 
-// .Motivation
 .Motivatie
-// Many stakeholders make architectural decision based on the technical interfaces between the system and its context.
 Veel belanghebbenden maken beslisisingen met betrekkeing tot de architectuur gebaseerd op de technische interfaces tussen het systeem en haar context.
-// Especially infrastructure or hardware designers decide these technical interfaces.
 Met name infrastructuur of hardware ontwerpers beslissen aan de hand van deze technische interfaces.
 
-// .Form
 .Vorm
-// E.g. UML deployment diagram describing channels to neighboring systems, together with a mapping table showing the relationships between channels and input/output.
 Bijvoorbeeld UML deployment diagrammen die de kanalen naar naburige systemen beschrijven, gecombineerd met mapping tabellen die de relatie tussen de kanalen en de input/output tonen.
 
 ****
 
-// **<Diagram or Table>**
 **<Diagram of Tabel>**
 
-// **<optionally: Explanation of technical interfaces>**
 **<optioneel: Uitleg van technische interfaces>**
 
-// **<Mapping Input/Output to Channels>**
 **<Mapping Input/Output naar kanalen>**

--- a/NL/asciidoc/src/04_solution_strategy.adoc
+++ b/NL/asciidoc/src/04_solution_strategy.adoc
@@ -1,0 +1,48 @@
+[[section-solution-strategy]]
+// == Solution Strategy
+== Oplossing Strategie
+
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// A short summary and explanation of the fundamental decisions and solution strategies, that shape system architecture. 
+Een korte samenvatting en uitleg van de fundamentele beslissingen en oplossings strategieen die de systeem architectuur vormen.
+// It includes
+Die bestaan uit onder andere
+
+// * technology decisions
+* beslissingen met betrekking tot technologie
+// * decisions about the top-level decomposition of the system, e.g. usage of an architectural pattern or design pattern
+* beslissingen over de top-level decompositie van het systeem, bijvoorbeeld het gebruik van een architectuur pattern of een design pattern
+// * decisions on how to achieve key quality goals
+* beslissingen over hoe de meest belangrijke kwaliteits doelen behaald zullen worden
+// * relevant organizational decisions, e.g. selecting a development process or delegating certain tasks to third parties.
+* relevante organisatorische beslissingen, bijvoorbeeld de keuze van een onwikkel proces of het delegeren van bepaalde taken aan derden.
+
+// .Motivation
+.Motivatie
+// These decisions form the cornerstones for your architecture.
+Deze beslissingen vormen het fundament van de architectuur.
+// They are the foundation for many other detailed decisions or implementation rules.
+Ze vormen de basis waarop vele andere gedetailleerde beslissingen of implemenatie regels worden gebaseerd.
+
+// .Form
+.Vorm
+// Keep the explanations of such key decisions short.
+Hou de uitleg van deze fundamentele beslissingen kort.
+
+// Motivate what was decided and why it was decided that way, based upon problem statement, quality goals and key constraints.
+Leg de motivatie en reden waarom van de beslissingen zo zijn genomen vast, gebaseerd op een probleem beschrijving, kwaliteitsdoelen en de belangrijkste kaders.
+// Refer to details in the following sections.
+Verwijs naar details in de volgende secties.
+
+
+// .Further Information
+.Verdere Informatie
+
+// See https://docs.arc42.org/section-4/[Solution Strategy] in the arc42 documentation.
+Zie https://docs.arc42.org/section-4/[Solution Strategy] in de arc42 documentatie.
+
+****

--- a/NL/asciidoc/src/04_solution_strategy.adoc
+++ b/NL/asciidoc/src/04_solution_strategy.adoc
@@ -1,48 +1,31 @@
 [[section-solution-strategy]]
-// == Solution Strategy
 == Oplossing Strategie
 
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// A short summary and explanation of the fundamental decisions and solution strategies, that shape system architecture. 
 Een korte samenvatting en uitleg van de fundamentele beslissingen en oplossings strategieen die de systeem architectuur vormen.
-// It includes
 Die bestaan uit onder andere
 
-// * technology decisions
 * beslissingen met betrekking tot technologie
-// * decisions about the top-level decomposition of the system, e.g. usage of an architectural pattern or design pattern
 * beslissingen over de top-level decompositie van het systeem, bijvoorbeeld het gebruik van een architectuur pattern of een design pattern
-// * decisions on how to achieve key quality goals
 * beslissingen over hoe de meest belangrijke kwaliteits doelen behaald zullen worden
-// * relevant organizational decisions, e.g. selecting a development process or delegating certain tasks to third parties.
 * relevante organisatorische beslissingen, bijvoorbeeld de keuze van een onwikkel proces of het delegeren van bepaalde taken aan derden.
 
-// .Motivation
 .Motivatie
-// These decisions form the cornerstones for your architecture.
 Deze beslissingen vormen het fundament van de architectuur.
-// They are the foundation for many other detailed decisions or implementation rules.
 Ze vormen de basis waarop vele andere gedetailleerde beslissingen of implemenatie regels worden gebaseerd.
 
-// .Form
 .Vorm
-// Keep the explanations of such key decisions short.
 Hou de uitleg van deze fundamentele beslissingen kort.
 
-// Motivate what was decided and why it was decided that way, based upon problem statement, quality goals and key constraints.
 Leg de motivatie en reden waarom van de beslissingen zo zijn genomen vast, gebaseerd op een probleem beschrijving, kwaliteitsdoelen en de belangrijkste kaders.
-// Refer to details in the following sections.
 Verwijs naar details in de volgende secties.
 
 
-// .Further Information
 .Verdere Informatie
 
-// See https://docs.arc42.org/section-4/[Solution Strategy] in the arc42 documentation.
 Zie https://docs.arc42.org/section-4/[Solution Strategy] in de arc42 documentatie.
 
 ****

--- a/NL/asciidoc/src/05_building_block_view.adoc
+++ b/NL/asciidoc/src/05_building_block_view.adoc
@@ -1,0 +1,287 @@
+[[section-building-block-view]]
+
+
+// == Building Block View
+== Bouwstenen View
+
+[role="arc42help"]
+****
+// .Content
+.Inhoud
+// The building block view shows the static decomposition of the system into building blocks (modules, components, subsystems, classes, interfaces, packages, libraries, frameworks, layers, partitions, tiers, functions, macros, operations, datas structures, ...) as well as their dependencies (relationships, associations, ...)
+De bouwstenen view toont de statische decompositie van het systeem in bouwstenen (modules, componenten, subsystemen, classes, interfaces, packages, libraries, frameworks, lagen, partitions, lagen, functies, macros, operaties, data structuren, ...) en hun onderlinge afhankelijkheden (relaties, associaties, ...).
+
+// This view is mandatory for every architecture documentation.
+Deze view is verplicht voor iedere architectuur documentatie.
+// In analogy to a house this is the _floor plan_.
+In termen van een huis is dit het _grond plan_.
+
+// .Motivation
+.Motivatie
+// Maintain an overview of your source code by making its structure understandable through abstraction.
+Hou een overzicht van de source code bij door de structuur begrijpelijk te maken door middel van abstracties.
+
+// This allows you to communicate with your stakeholder on an abstract level without disclosing implementation details.
+Dit zorgt ervoor dat het mogelijk is om op een abstract niveau te communiceren met de belanghebbenden zonder daarbij op implementatie details in te hoeven gaan.
+
+// .Form
+.Vorm
+// The building block view is a hierarchical collection of black boxes and white boxes (see figure below) and their descriptions.
+De bouwstenen view is een hiërarchische verzameling van 'black boxes' en 'white boxes' (zie het onderstaande plaatje) met de bijbehorende beschrijvingen.
+
+// image::05_building_blocks-EN.png["Hierarchy of building blocks"]
+image::05_building_blocks-NL.png["Hiërarchie van bouwstenen"]
+
+// *Level 1* is the white box description of the overall system together with black box descriptions of all contained building blocks.
+*Niveau 1* is een 'white box' beschijving van het gehele systeem gecombineerd met 'black box' beschrijvingen van alle ingesloten bouwstenen.
+
+// *Level 2* zooms into some building blocks of level 1.
+*Niveau 2* zoomt in op sommige bouwstenen uit niveau 1.
+// Thus it contains the white box description of selected building blocks of level 1, together with black box descriptions of their internal building blocks.
+Zodoende bevat het de 'white box' beschrijving van specifieke bouwstenen uit niveau 1, gecombineerd met 'black box' beschrijvingen van hun interne bouwstenen.
+
+// *Level 3* zooms into selected building blocks of level 2, and so on.
+*Niveau 3* zoomt in op geslecteerde bouwstenen uit niveau 2, en zo verder.
+
+
+// .Further Information
+.Verdere Informatie
+
+// See https://docs.arc42.org/section-5/[Building Block View] in the arc42 documentation.
+Zie https://docs.arc42.org/section-5/[Building Block View] in de arc42 documentatie.
+
+****
+
+// === Whitebox Overall System
+=== Gehele whitebox Systeem
+
+[role="arc42help"]
+****
+// Here you describe the decomposition of the overall system using the following white box template.
+Hier wordt de decompositie van het gheele systeem beschreven aan de hand van het volgende 'white box' template.
+// It contains
+Hij bestaat uit
+
+//  * an overview diagram
+* een overzichts diagram
+//  * a motivation for the decomposition
+* een motivatie voor de decompositie
+//  * black box descriptions of the contained building blocks.
+* 'black box' beschrijvingen van ingesloten bouwstenen.
+// For these we offer you alternatives:
+Hiervoor zijn er verschillende alternatieven:
+//  ** use _one_ table for a short and pragmatic overview of all contained building blocks and their interfaces
+** gebruik _één_ tabel for een korte en pragmatisch overzicht van alle ingesloten bouwstenen en hun interfaces.
+//  ** use a list of black box descriptions of the building blocks according to the black box template (see below).
+** gebruik een lijst met 'black box' beschrijvingen van de bouwstenen aan de hand van het 'black box' template (zie hieronder).
+//  Depending on your choice of tool this list could be sub-chapters (in text files), sub-pages (in a Wiki) or nested elements (in a modeling tool).
+Afhankelijk van de gebruikte tool kan deze lijst in de vorm van een sub-hoofdstuk (in tekst bestanden), sub-pagina's (in een Wiki) of geneste elementen (in een modelleer tool) zijn.
+
+//  * (optional:) important interfaces, that are not explained in the black box templates of a building block, but are very important for understanding the white box.
+* (optioneel:) belangrijke interfaces die niet in de 'black box' templates van de bouwstenen worden uitgelegd maar desondanks van belang zijn om de 'white box' goed te kunnen begrijpen.
+// Since there are so many ways to specify interfaces why do not provide a specific template for them.
+Omdat er zo veel verschillende manieren zijn om interfaces te specificeren wordt er geen specifiek template aangeboden.
+//  In the worst case you have to specify and describe syntax, semantics, protocols, error handling, restrictions, versions, qualities, necessary compatibilities and many things more.
+In het ergste geval moeten syntax, semantiek, protocollen, error afhandeling, beperkingen, versies, kwaliteits attributen, benodigde compatibiliteit en vele andere zaken gespecificeerd en beschreven worden.
+// In the best case you will get away with examples or simple signatures.
+In het beste geval zijn voorbeelden of simpele beschrijvingen voldoende.
+
+****
+
+// _**<Overview Diagram>**_
+_**<Overzichts Diagram>**_
+
+// Motivation::
+Motivatie::
+
+// _<text explanation>_
+_<tekstuele uitleg>_
+
+
+// Contained Building Blocks::
+Ingesloten bouwstenen::
+// _<Description of contained building block (black boxes)>_
+_<Beschrijving van ingesloten bouwstenen ('black boxes')>_
+
+// Important Interfaces::
+Belangrijke Interfaces::
+// _<Description of important interfaces>_
+_<Beschrijving van belangrijke interfaces>_
+
+[role="arc42help"]
+****
+// Insert your explanations of black boxes from level 1:
+Voeg hier de uitleg van de 'black boxes' van niveau 1 toe:
+
+// If you use tabular form you will only describe your black boxes with name and responsibility according to the following schema:
+In tabel vorm moeten hier enkel de 'black boxes' met hun naam een verantwoordelijkheden worden beschreven:
+
+[cols="1,2" options="header"]
+|===
+// | **Name** | **Responsibility**
+| **Naam** | **Verantwoordelijkeid**
+// | _<black box 1>_ | _<Text>_
+| _<black box 1>_ | _<Tekst>_
+// | _<black box 2>_ | _<Text>_
+| _<black box 2>_ | _<Tekst>_
+|===
+
+
+
+// If you use a list of black box descriptions then you fill in a separate black box template for every important building block .
+In het geval er een lijst met 'black box' beschrijvingen wordt gebruikt, vul dan een aparte 'black box' template in voor iedere belangrijke bouwsteen.
+// Its headline is the name of the black box.
+De kop bij die sectie is dan de naam van de specifieke 'black box'.
+****
+
+
+// ==== <Name black box 1>
+==== <Naam black box 1>
+
+[role="arc42help"]
+****
+// Here you describe <black box 1>
+Beschrijf hier <'black box' 1>
+// according the the following black box template:
+Aan de hand van de onderstaande 'black box' template:
+
+// * Purpose/Responsibility
+* Doel/Verantwoordelijkheid
+// * Interface(s), when they are not extracted as separate paragraphs. This interfaces may include qualities and performance characteristics.
+* Interface(s), als ze niet als aparte paragraven worden geadresseerd.
+Deze interface beschrijvingen kunnen kwaliteit en prestatie karakteristieken bevatten.
+// * (Optional) Quality-/Performance characteristics of the black box, e.g.availability, run time behavior, ....
+* (Optioneel) Kwaliteits-/Prestatie karakteristieken van de 'black box', bijvoorbeeld beschikbaarheid, run time gedrag, ....
+// * (Optional) directory/file location
+* (Optioneel) directories/bestand locaties
+// * (Optional) Fulfilled requirements (if you need traceability to requirements).
+* (Optioneel) Vervulde requirements (als er traceerbaarheid van de requirements is vereist)
+// * (Optional) Open issues/problems/risks
+* (Optioneel) Open issues/problemen/risico's
+****
+
+// _<Purpose/Responsibility>_
+_<Doel/Verantwoordelijkheid>_
+
+// _<Interface(s)>_
+_<Interface(s)>_
+
+// _<(Optional) Quality/Performance Characteristics>_
+_<((Optioneel) Kwaliteits-/Prestatie karakteristieken>_
+
+// _<(Optional) Directory/File Location>_
+_<(Optioneel) directories/bestand locaties>_
+
+// _<(Optional) Fulfilled Requirements>_
+_<(Optioneel) Vervulde requirements>_
+
+// _<(optional) Open Issues/Problems/Risks>_
+_<(Optioneel) Open issues/problemen/risico's>_
+
+
+// ==== <Name black box 2>
+=== <Naam black box 2>
+
+// _<black box template>_
+_<black box template>_
+
+// ==== <Name black box n>
+==== <Naam black box n>
+
+// _<black box template>_
+_<black box template>_
+
+
+// ==== <Name interface 1>
+==== <Naam interface 1>
+
+...
+
+// ==== <Name interface m>
+==== <Naam interface m>
+
+
+
+// === Level 2
+=== Niveau 2
+
+[role="arc42help"]
+****
+// Here you can specify the inner structure of (some) building blocks from level 1 as white boxes.
+Hier kunnen de innerlijke structuren van (sommige) bouwstenen uit niveau 1 als 'white boxes' worden gespecificeerd.
+
+// You have to decide which building blocks of your system are important enough to justify such a detailed description.
+Er moet een keuze gemaakt worden voor welke bouwstenen het gerechtvaardigd is om zo'n gedetailleerde beschrijving te maken.
+// Please prefer relevance over completeness.
+Geeft de voorkeur aan relevantie boven compleetheid.
+// Specify important, surprising, risky, complex or volatile building blocks.
+Beschrijf belangrijke, verassende, risicovolle, complexe of vluchtige bouwstenen.
+// Leave out normal, simple, boring or standardized parts of your system
+Laat normale, simpele, saaie of gestandardiseerde delen van het systeem buiten beschouwing.
+****
+
+// ==== White Box _<building block 1>_
+==== White Box _<bouwsteen 1>_
+
+[role="arc42help"]
+****
+// ...describes the internal structure of _building block 1_.
+...beschrijft de interne structuur van _bouwsteen 1_.
+****
+
+_<white box template>_
+
+// ==== White Box _<building block 2>_
+==== White Box _<bouwsteen 2>_
+
+
+_<white box template>_
+
+...
+
+// ==== White Box _<building block m>_
+==== White Box _<bouwsteen m>_
+
+
+_<white box template>_
+
+
+
+// === Level 3
+=== Niveau 3
+
+[role="arc42help"]
+****
+// Here you can specify the inner structure of (some) building blocks from level 2 as white boxes.
+Hier kan de interne structuur van (sommige) niveau 2 bouwstenen als 'white boxes' worden beschreven.
+
+// When you need more detailed levels of your architecture please copy this part of arc42 for additional levels.
+Als er meer gedetailleerde niveaus van de architectuur nodig zijn, kopieer dan dit deel van arc42 voor aanvullende niveaus.
+****
+
+
+// ==== White Box <_building block x.1_>
+==== White Box _<bouwsteen x.1>_
+
+[role="arc42help"]
+****
+// Specifies the internal structure of _building block x.1_.
+Specificeer de interne structuur van _bouwsteen x.1_.
+
+****
+
+
+_<white box template>_
+
+
+// ==== White Box <_building block x.2_>
+==== White Box _<bouwsteen x.2>_
+
+_<white box template>_
+
+
+
+// ==== White Box <_building block y.1_>
+==== White Box _<bouwsteen y.1>_
+
+_<white box template>_

--- a/NL/asciidoc/src/05_building_block_view.adoc
+++ b/NL/asciidoc/src/05_building_block_view.adoc
@@ -1,237 +1,161 @@
 [[section-building-block-view]]
 
 
-// == Building Block View
 == Bouwstenen View
 
 [role="arc42help"]
 ****
-// .Content
 .Inhoud
-// The building block view shows the static decomposition of the system into building blocks (modules, components, subsystems, classes, interfaces, packages, libraries, frameworks, layers, partitions, tiers, functions, macros, operations, datas structures, ...) as well as their dependencies (relationships, associations, ...)
 De bouwstenen view toont de statische decompositie van het systeem in bouwstenen (modules, componenten, subsystemen, classes, interfaces, packages, libraries, frameworks, lagen, partitions, lagen, functies, macros, operaties, data structuren, ...) en hun onderlinge afhankelijkheden (relaties, associaties, ...).
 
-// This view is mandatory for every architecture documentation.
 Deze view is verplicht voor iedere architectuur documentatie.
-// In analogy to a house this is the _floor plan_.
 In termen van een huis is dit het _grond plan_.
 
-// .Motivation
 .Motivatie
-// Maintain an overview of your source code by making its structure understandable through abstraction.
 Hou een overzicht van de source code bij door de structuur begrijpelijk te maken door middel van abstracties.
 
-// This allows you to communicate with your stakeholder on an abstract level without disclosing implementation details.
 Dit zorgt ervoor dat het mogelijk is om op een abstract niveau te communiceren met de belanghebbenden zonder daarbij op implementatie details in te hoeven gaan.
 
-// .Form
 .Vorm
-// The building block view is a hierarchical collection of black boxes and white boxes (see figure below) and their descriptions.
 De bouwstenen view is een hiërarchische verzameling van 'black boxes' en 'white boxes' (zie het onderstaande plaatje) met de bijbehorende beschrijvingen.
 
-// image::05_building_blocks-EN.png["Hierarchy of building blocks"]
-image::05_building_blocks-NL.png["Hiërarchie van bouwstenen"]
+image::05_building_blocks-EN.png["Hiërarchie van bouwstenen"]
 
-// *Level 1* is the white box description of the overall system together with black box descriptions of all contained building blocks.
 *Niveau 1* is een 'white box' beschijving van het gehele systeem gecombineerd met 'black box' beschrijvingen van alle ingesloten bouwstenen.
 
-// *Level 2* zooms into some building blocks of level 1.
 *Niveau 2* zoomt in op sommige bouwstenen uit niveau 1.
-// Thus it contains the white box description of selected building blocks of level 1, together with black box descriptions of their internal building blocks.
 Zodoende bevat het de 'white box' beschrijving van specifieke bouwstenen uit niveau 1, gecombineerd met 'black box' beschrijvingen van hun interne bouwstenen.
 
-// *Level 3* zooms into selected building blocks of level 2, and so on.
 *Niveau 3* zoomt in op geslecteerde bouwstenen uit niveau 2, en zo verder.
 
 
-// .Further Information
 .Verdere Informatie
 
-// See https://docs.arc42.org/section-5/[Building Block View] in the arc42 documentation.
 Zie https://docs.arc42.org/section-5/[Building Block View] in de arc42 documentatie.
 
 ****
 
-// === Whitebox Overall System
 === Gehele whitebox Systeem
 
 [role="arc42help"]
 ****
-// Here you describe the decomposition of the overall system using the following white box template.
-Hier wordt de decompositie van het gheele systeem beschreven aan de hand van het volgende 'white box' template.
-// It contains
-Hij bestaat uit
+Hier wordt de decompositie van het gehele systeem beschreven aan de hand van het volgende 'white box' template.
+Die bestaat uit
 
-//  * an overview diagram
 * een overzichts diagram
-//  * a motivation for the decomposition
 * een motivatie voor de decompositie
-//  * black box descriptions of the contained building blocks.
 * 'black box' beschrijvingen van ingesloten bouwstenen.
-// For these we offer you alternatives:
 Hiervoor zijn er verschillende alternatieven:
-//  ** use _one_ table for a short and pragmatic overview of all contained building blocks and their interfaces
-** gebruik _één_ tabel for een korte en pragmatisch overzicht van alle ingesloten bouwstenen en hun interfaces.
-//  ** use a list of black box descriptions of the building blocks according to the black box template (see below).
-** gebruik een lijst met 'black box' beschrijvingen van de bouwstenen aan de hand van het 'black box' template (zie hieronder).
-//  Depending on your choice of tool this list could be sub-chapters (in text files), sub-pages (in a Wiki) or nested elements (in a modeling tool).
-Afhankelijk van de gebruikte tool kan deze lijst in de vorm van een sub-hoofdstuk (in tekst bestanden), sub-pagina's (in een Wiki) of geneste elementen (in een modelleer tool) zijn.
+  ** gebruik _één_ tabel for een korte en pragmatisch overzicht van alle ingesloten bouwstenen en hun interfaces.
+  ** gebruik een lijst met 'black box' beschrijvingen van de bouwstenen aan de hand van het 'black box' template (zie hieronder).
+  Afhankelijk van de gebruikte tool kan deze lijst in de vorm van een sub-hoofdstuk (in tekst bestanden), sub-pagina's (in een Wiki) of geneste elementen (in een modelleer tool) zijn.
 
-//  * (optional:) important interfaces, that are not explained in the black box templates of a building block, but are very important for understanding the white box.
 * (optioneel:) belangrijke interfaces die niet in de 'black box' templates van de bouwstenen worden uitgelegd maar desondanks van belang zijn om de 'white box' goed te kunnen begrijpen.
-// Since there are so many ways to specify interfaces why do not provide a specific template for them.
 Omdat er zo veel verschillende manieren zijn om interfaces te specificeren wordt er geen specifiek template aangeboden.
-//  In the worst case you have to specify and describe syntax, semantics, protocols, error handling, restrictions, versions, qualities, necessary compatibilities and many things more.
 In het ergste geval moeten syntax, semantiek, protocollen, error afhandeling, beperkingen, versies, kwaliteits attributen, benodigde compatibiliteit en vele andere zaken gespecificeerd en beschreven worden.
-// In the best case you will get away with examples or simple signatures.
 In het beste geval zijn voorbeelden of simpele beschrijvingen voldoende.
 
 ****
 
-// _**<Overview Diagram>**_
 _**<Overzichts Diagram>**_
 
-// Motivation::
 Motivatie::
 
-// _<text explanation>_
 _<tekstuele uitleg>_
 
 
-// Contained Building Blocks::
 Ingesloten bouwstenen::
-// _<Description of contained building block (black boxes)>_
 _<Beschrijving van ingesloten bouwstenen ('black boxes')>_
 
-// Important Interfaces::
 Belangrijke Interfaces::
-// _<Description of important interfaces>_
 _<Beschrijving van belangrijke interfaces>_
 
 [role="arc42help"]
 ****
-// Insert your explanations of black boxes from level 1:
 Voeg hier de uitleg van de 'black boxes' van niveau 1 toe:
 
-// If you use tabular form you will only describe your black boxes with name and responsibility according to the following schema:
 In tabel vorm moeten hier enkel de 'black boxes' met hun naam een verantwoordelijkheden worden beschreven:
 
 [cols="1,2" options="header"]
 |===
-// | **Name** | **Responsibility**
 | **Naam** | **Verantwoordelijkeid**
-// | _<black box 1>_ | _<Text>_
 | _<black box 1>_ | _<Tekst>_
-// | _<black box 2>_ | _<Text>_
 | _<black box 2>_ | _<Tekst>_
 |===
 
 
-
-// If you use a list of black box descriptions then you fill in a separate black box template for every important building block .
 In het geval er een lijst met 'black box' beschrijvingen wordt gebruikt, vul dan een aparte 'black box' template in voor iedere belangrijke bouwsteen.
-// Its headline is the name of the black box.
 De kop bij die sectie is dan de naam van de specifieke 'black box'.
 ****
 
 
-// ==== <Name black box 1>
 ==== <Naam black box 1>
 
 [role="arc42help"]
 ****
-// Here you describe <black box 1>
 Beschrijf hier <'black box' 1>
-// according the the following black box template:
 Aan de hand van de onderstaande 'black box' template:
 
-// * Purpose/Responsibility
 * Doel/Verantwoordelijkheid
-// * Interface(s), when they are not extracted as separate paragraphs. This interfaces may include qualities and performance characteristics.
 * Interface(s), als ze niet als aparte paragraven worden geadresseerd.
 Deze interface beschrijvingen kunnen kwaliteit en prestatie karakteristieken bevatten.
-// * (Optional) Quality-/Performance characteristics of the black box, e.g.availability, run time behavior, ....
 * (Optioneel) Kwaliteits-/Prestatie karakteristieken van de 'black box', bijvoorbeeld beschikbaarheid, run time gedrag, ....
-// * (Optional) directory/file location
 * (Optioneel) directories/bestand locaties
-// * (Optional) Fulfilled requirements (if you need traceability to requirements).
 * (Optioneel) Vervulde requirements (als er traceerbaarheid van de requirements is vereist)
-// * (Optional) Open issues/problems/risks
 * (Optioneel) Open issues/problemen/risico's
 ****
 
-// _<Purpose/Responsibility>_
 _<Doel/Verantwoordelijkheid>_
 
-// _<Interface(s)>_
 _<Interface(s)>_
 
-// _<(Optional) Quality/Performance Characteristics>_
 _<((Optioneel) Kwaliteits-/Prestatie karakteristieken>_
 
-// _<(Optional) Directory/File Location>_
 _<(Optioneel) directories/bestand locaties>_
 
-// _<(Optional) Fulfilled Requirements>_
 _<(Optioneel) Vervulde requirements>_
 
-// _<(optional) Open Issues/Problems/Risks>_
 _<(Optioneel) Open issues/problemen/risico's>_
 
 
-// ==== <Name black box 2>
 === <Naam black box 2>
 
-// _<black box template>_
 _<black box template>_
 
-// ==== <Name black box n>
 ==== <Naam black box n>
 
-// _<black box template>_
 _<black box template>_
 
 
-// ==== <Name interface 1>
 ==== <Naam interface 1>
 
 ...
 
-// ==== <Name interface m>
 ==== <Naam interface m>
 
 
 
-// === Level 2
 === Niveau 2
 
 [role="arc42help"]
 ****
-// Here you can specify the inner structure of (some) building blocks from level 1 as white boxes.
 Hier kunnen de innerlijke structuren van (sommige) bouwstenen uit niveau 1 als 'white boxes' worden gespecificeerd.
 
-// You have to decide which building blocks of your system are important enough to justify such a detailed description.
 Er moet een keuze gemaakt worden voor welke bouwstenen het gerechtvaardigd is om zo'n gedetailleerde beschrijving te maken.
-// Please prefer relevance over completeness.
 Geeft de voorkeur aan relevantie boven compleetheid.
-// Specify important, surprising, risky, complex or volatile building blocks.
 Beschrijf belangrijke, verassende, risicovolle, complexe of vluchtige bouwstenen.
-// Leave out normal, simple, boring or standardized parts of your system
 Laat normale, simpele, saaie of gestandardiseerde delen van het systeem buiten beschouwing.
 ****
 
-// ==== White Box _<building block 1>_
 ==== White Box _<bouwsteen 1>_
 
 [role="arc42help"]
 ****
-// ...describes the internal structure of _building block 1_.
 ...beschrijft de interne structuur van _bouwsteen 1_.
 ****
 
 _<white box template>_
 
-// ==== White Box _<building block 2>_
 ==== White Box _<bouwsteen 2>_
 
 
@@ -239,7 +163,6 @@ _<white box template>_
 
 ...
 
-// ==== White Box _<building block m>_
 ==== White Box _<bouwsteen m>_
 
 
@@ -247,25 +170,20 @@ _<white box template>_
 
 
 
-// === Level 3
 === Niveau 3
 
 [role="arc42help"]
 ****
-// Here you can specify the inner structure of (some) building blocks from level 2 as white boxes.
 Hier kan de interne structuur van (sommige) niveau 2 bouwstenen als 'white boxes' worden beschreven.
 
-// When you need more detailed levels of your architecture please copy this part of arc42 for additional levels.
 Als er meer gedetailleerde niveaus van de architectuur nodig zijn, kopieer dan dit deel van arc42 voor aanvullende niveaus.
 ****
 
 
-// ==== White Box <_building block x.1_>
 ==== White Box _<bouwsteen x.1>_
 
 [role="arc42help"]
 ****
-// Specifies the internal structure of _building block x.1_.
 Specificeer de interne structuur van _bouwsteen x.1_.
 
 ****
@@ -274,14 +192,12 @@ Specificeer de interne structuur van _bouwsteen x.1_.
 _<white box template>_
 
 
-// ==== White Box <_building block x.2_>
 ==== White Box _<bouwsteen x.2>_
 
 _<white box template>_
 
 
 
-// ==== White Box <_building block y.1_>
 ==== White Box _<bouwsteen y.1>_
 
 _<white box template>_

--- a/NL/asciidoc/src/06_runtime_view.adoc
+++ b/NL/asciidoc/src/06_runtime_view.adoc
@@ -1,0 +1,75 @@
+[[section-runtime-view]]
+== Runtime View
+
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// The runtime view describes concrete behavior and interactions of the system’s building blocks in form of scenarios from the following areas:
+De runtime view beschrijft concreet gedrag en de interacties tussen de bouwstenen van het systeem vanuit de volgende gebieden:
+
+// * important use cases or features: how do building blocks execute them?
+* belangrijke use cases of eigenschappen: op welke manier voeren de bouwstenen deze uit?
+// * interactions at critical external interfaces: how do building blocks cooperate with users and neighboring systems?
+* interactie bij kritieke externe interfaces: hoe werken bouwstenen samen met gebruikers en aanpalende systemen?
+// * operation and administration: launch, start-up, stop
+* operations en administrie: uitvoeren, starten, stoppen
+// * error and exception scenarios
+* error en uitzonderlijke (exception) scenarios
+
+// Remark: The main criterion for the choice of possible scenarios (sequences, workflows) is their *architectural relevance*.
+NOTE: Het primaire criterium bij de keuze van mogelijke scenarios (sequences, workflows) is de relevantie met betrekking tot de architectuur.
+// It is *not* important to describe a large number of scenarios.
+Het is uitdrukkelijk *niet* van belang om een groot aantal scenarios te beschrijven.
+// You should rather document a representative selection.
+Beschrijf liever een representatieve doorsnede.
+
+
+// .Motivation
+.Motivatie
+// You should understand how (instances of) building blocks of your system perform their job and communicate at runtime.
+Beschrijft hoe (instanties van) bouwstenen van het systeem hun taken uitvoeren en hoe ze 'at runtime' communiceren.
+
+// You will mainly capture scenarios in your documentation to communicate your architecture to stakeholders that are less willing or able to read and understand the static models (building block view, deployment view).
+De scenarios zullen hoofdzakelijk beschreven worden om de architectuur aan belanghebbenden te communiceren die minder behoefte of kunde hebben om statische modellen (bouwstenen view, deploy view) te lezen en te doorgronden.
+
+// .Form
+.Vorm
+// There are many notations for describing scenarios, e.g.
+Er zijn meerdere manieren om de schenarios vast te leggen, bijvoorbeeld
+
+// * numbered list of steps (in natural language)
+* (uitgeschreven) opsomming van de stappen
+// * activity diagrams or flow charts
+* activiteiten of flow diagrammen
+// * sequence diagrams
+* sequence diagrammen
+// * BPMN or EPCs (event process chains)
+* BPMN of EPCs (event process chains)
+// * state machines
+* state machines
+* ...
+
+
+// .Further Information
+.Verdere Informatie
+
+// See https://docs.arc42.org/section-6/[Runtime View] in the arc42 documentation.
+Zie https://docs.arc42.org/section-6/[Runtime View] in de arc42 documentatie.
+
+****
+
+=== <Runtime Scenario 1>
+
+
+// * _<insert runtime diagram or textual description of the scenario>_
+* _<voeg een runtime diagram of een tekstuele beschrijving van het scenario toe>_
+// * _<insert description of the notable aspects of the interactions between the building block instances depicted in this diagram.>_
+* _<voeg een beschrijving toe van bijzondere aspecten van de interactie tussen de instanties van de bouwstenen die in dit diagram worden weergegeven>_
+
+=== <Runtime Scenario 2>
+
+=== ...
+
+=== <Runtime Scenario n>

--- a/NL/asciidoc/src/06_runtime_view.adoc
+++ b/NL/asciidoc/src/06_runtime_view.adoc
@@ -4,58 +4,37 @@
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// The runtime view describes concrete behavior and interactions of the system’s building blocks in form of scenarios from the following areas:
 De runtime view beschrijft concreet gedrag en de interacties tussen de bouwstenen van het systeem vanuit de volgende gebieden:
 
-// * important use cases or features: how do building blocks execute them?
 * belangrijke use cases of eigenschappen: op welke manier voeren de bouwstenen deze uit?
-// * interactions at critical external interfaces: how do building blocks cooperate with users and neighboring systems?
 * interactie bij kritieke externe interfaces: hoe werken bouwstenen samen met gebruikers en aanpalende systemen?
-// * operation and administration: launch, start-up, stop
 * operations en administrie: uitvoeren, starten, stoppen
-// * error and exception scenarios
 * error en uitzonderlijke (exception) scenarios
 
-// Remark: The main criterion for the choice of possible scenarios (sequences, workflows) is their *architectural relevance*.
 NOTE: Het primaire criterium bij de keuze van mogelijke scenarios (sequences, workflows) is de relevantie met betrekking tot de architectuur.
-// It is *not* important to describe a large number of scenarios.
 Het is uitdrukkelijk *niet* van belang om een groot aantal scenarios te beschrijven.
-// You should rather document a representative selection.
 Beschrijf liever een representatieve doorsnede.
 
 
-// .Motivation
 .Motivatie
-// You should understand how (instances of) building blocks of your system perform their job and communicate at runtime.
 Beschrijft hoe (instanties van) bouwstenen van het systeem hun taken uitvoeren en hoe ze 'at runtime' communiceren.
 
-// You will mainly capture scenarios in your documentation to communicate your architecture to stakeholders that are less willing or able to read and understand the static models (building block view, deployment view).
 De scenarios zullen hoofdzakelijk beschreven worden om de architectuur aan belanghebbenden te communiceren die minder behoefte of kunde hebben om statische modellen (bouwstenen view, deploy view) te lezen en te doorgronden.
 
-// .Form
 .Vorm
-// There are many notations for describing scenarios, e.g.
 Er zijn meerdere manieren om de schenarios vast te leggen, bijvoorbeeld
 
-// * numbered list of steps (in natural language)
 * (uitgeschreven) opsomming van de stappen
-// * activity diagrams or flow charts
 * activiteiten of flow diagrammen
-// * sequence diagrams
 * sequence diagrammen
-// * BPMN or EPCs (event process chains)
 * BPMN of EPCs (event process chains)
-// * state machines
 * state machines
 * ...
 
 
-// .Further Information
 .Verdere Informatie
 
-// See https://docs.arc42.org/section-6/[Runtime View] in the arc42 documentation.
 Zie https://docs.arc42.org/section-6/[Runtime View] in de arc42 documentatie.
 
 ****
@@ -63,9 +42,7 @@ Zie https://docs.arc42.org/section-6/[Runtime View] in de arc42 documentatie.
 === <Runtime Scenario 1>
 
 
-// * _<insert runtime diagram or textual description of the scenario>_
 * _<voeg een runtime diagram of een tekstuele beschrijving van het scenario toe>_
-// * _<insert description of the notable aspects of the interactions between the building block instances depicted in this diagram.>_
 * _<voeg een beschrijving toe van bijzondere aspecten van de interactie tussen de instanties van de bouwstenen die in dit diagram worden weergegeven>_
 
 === <Runtime Scenario 2>

--- a/NL/asciidoc/src/07_deployment_view.adoc
+++ b/NL/asciidoc/src/07_deployment_view.adoc
@@ -1,0 +1,140 @@
+[[section-deployment-view]]
+
+
+// == Deployment View
+== Deployment View
+
+[role="arc42help"]
+****
+// .Content
+.Inhoud
+// The deployment view describes:
+De deployment view beschrijft:
+
+//  1. technical infrastructure used to execute your system, with infrastructure elements like geographical locations, environments, computers, processors, channels and net topologies as well as other infrastructure elements and
+1. de benodigede technische infrastructuur om het systeem uit te kunnen voeren, met infrastructurele elementen zoals geografische locatie, omgeving, computers, processors, kanalen en netwerk topologie als ook andere infrastructurele elementen; 
+// 2. mapping of (software) building blocks to that infrastructure elements.
+2. mapping van (software) bouwstenen naar infrastructuur elementen.
+
+// Often systems are executed in different environments, e.g. development environment, test environment, production environment.
+Vaak worden systeem in verschillende omgevingen gedraaid, e.g. ontwikkel omgeving, test omgeving, productie omgeving.
+// In such cases you should document all relevant environments.
+In zulke gevallen moeten alle relevevante omgevingen worden gedocumenteerd.
+
+// Especially document a deployment view if your software is executed as distributed system with more than one computer, processor, server or container or when you design and construct your own hardware processors and chips.
+In het bijzonder als de software wordt uitgevoerd op een gedistribueerd systeem, met meer dan een computer, processor, server of container _of_ als er gebruik wordt gemaakt van zelf ontworpen hardware en/of chips, is het van belang om de deployment view vast te leggen.
+
+// From a software perspective it is sufficient to capture only those elements of an infrastructure that are needed to show a deployment of your building blocks.
+Vanuit een software perspectief is het voldoende om alleen die elementen van de infrastrucuur vast te leggen die nodig zijn om de deployment view van de bouwstenen te tonen.
+// Hardware architects can go beyond that and describe an infrastructure to any level of detail they need to capture.
+Hardware architecten kunnen verder gaan en de infrastruur beschrijven tot het detail niveau dat voor hun passend is.
+
+// .Motivation
+.Motivatie
+// Software does not run without hardware.
+Software draait niet zonder hardware.
+// This underlying infrastructure can and will influence a system and/or some cross-cutting concepts.
+Deze onderliggende infrastructuur heeft invloed om het systeem en/of sommige cross-cutting concepten.
+// Therefore, there is a need to know the infrastructure.
+Daarom is het van belang kennis te hebben van de infrastructuur.
+
+// .Form
+.Vorm
+
+// Maybe a highest level deployment diagram is already contained in section 3.2. as technical context with your own infrastructure as ONE black box. 
+Mogelijk is er op het hoogste niveau al een deployment diagram opgenomen in paragraaf 3.2. als technische context met de eigen infrastructuur als 1 "black box".
+
+// In this section one can zoom into this black box using additional deployment diagrams:
+In deze paragraaf kan worden ingezoomd op deze "black box" met aanvullende deployment diagrammen:
+
+// * UML offers deployment diagrams to express that view.
+* UML bied deployment diagrammen om die view weer te geven.
+// Use it, probably with nested diagrams, when your infrastructure is more complex.
+Gebruik deze, eventueel met geneste diagrammen, als de infrastructuur ingewikkelder is.
+// * When your (hardware) stakeholders prefer other kinds of diagrams rather than a deployment diagram, let them use any kind that is able to show nodes and channels of the infrastructure.
+* Als de (hardware) belanghebbenden er de voorkeur aan geven kunnen ander type diagrammen gebruikt worden.
+Gebruik passende diagrammen om de nodes en kanalen van de infrastructuur weer te geven.
+
+
+// .Further Information
+.Verdere Informatie
+
+// See https://docs.arc42.org/section-7/[Deployment View] in the arc42 documentation.
+Zie https://docs.arc42.org/section-7/[Deployment View] in de arc42 documentatie.
+
+****
+
+// === Infrastructure Level 1
+=== Infrastructuur Niveau 1
+
+[role="arc42help"]
+****
+// Describe (usually in a combination of diagrams, tables, and text):
+Beschrijf (normaliter in een combinatie van diagrammen, tabellen en text):
+
+// * distribution of a system to multiple locations, environments, computers, processors, .., as well as physical connections between them
+* distributie van het systeem over meerdere locaties, omgevingen, computers, processors, .., als ook de fysieke verbindingen ertussen
+// * important justifications or motivations for this deployment structure
+* verantwoording of motivatie voor deze deployment strucuur
+// * quality and/or performance features of this infrastructure
+* kwaliteit en/of performance attributen van deze infrastructuur
+// * mapping of software artifacts to elements of this infrastructure
+*  mapping van software artifacten naar elementen van deze infrastructuur
+
+// For multiple environments or alternative deployments please copy and adapt this section of arc42 for all relevant environments.
+Als er sprake is van meerdere omgevingen of alternatieve deployments kopieer en pas deze paragraaf van arc42 aan voor alle relevente omgevingen. 
+
+****
+
+// _**<Overview Diagram>**_
+_**<Overzichts Diagram>**_
+
+// Motivation::
+Motivatie::
+
+// _<explanation in text form>_
+_<uitleg in tekstuele vorm>_
+
+// Quality and/or Performance Features::
+Kwaliteit en/of Performance Eigenschappen::
+
+// _<explanation in text form>_
+_<uitleg in tekstuele vorm>_
+
+// Mapping of Building Blocks to Infrastructure::
+Mapping van Bouwblokken naar Infrastructuur::
+// _<description of the mapping>_
+_<beschrijving van de mapping>_
+
+
+// === Infrastructure Level 2
+=== Infrastructuur Niveau 2
+
+[role="arc42help"]
+****
+// Here you can include the internal structure of (some) infrastructure elements from level 1.
+Hier kunnen de interne structuren van (sommige) infrastructuur elementen uit niveau 1 worden toegevoegd.
+
+// Please copy the structure from level 1 for each selected element.
+Kopieer de structuur van niveau 1 voor ieder geselecteerd element.
+****
+
+// ==== _<Infrastructure Element 1>_
+==== _<Infrastructuur Element 1>_
+
+// _<diagram + explanation>_
+_<diagram + uitleg>_
+
+// ==== _<Infrastructure Element 2>_
+==== _<Infrastructuur Element 2>_
+
+// _<diagram + explanation>_
+_<diagram + uitleg>_
+
+...
+
+// ==== _<Infrastructure Element n>_
+==== _<Infrastructuur Element n>_
+
+// _<diagram + explanation>_
+_<diagram + uitleg>_

--- a/NL/asciidoc/src/07_deployment_view.adoc
+++ b/NL/asciidoc/src/07_deployment_view.adoc
@@ -1,140 +1,95 @@
 [[section-deployment-view]]
 
 
-// == Deployment View
 == Deployment View
 
 [role="arc42help"]
 ****
-// .Content
 .Inhoud
-// The deployment view describes:
 De deployment view beschrijft:
 
-//  1. technical infrastructure used to execute your system, with infrastructure elements like geographical locations, environments, computers, processors, channels and net topologies as well as other infrastructure elements and
 1. de benodigede technische infrastructuur om het systeem uit te kunnen voeren, met infrastructurele elementen zoals geografische locatie, omgeving, computers, processors, kanalen en netwerk topologie als ook andere infrastructurele elementen; 
-// 2. mapping of (software) building blocks to that infrastructure elements.
 2. mapping van (software) bouwstenen naar infrastructuur elementen.
 
-// Often systems are executed in different environments, e.g. development environment, test environment, production environment.
 Vaak worden systeem in verschillende omgevingen gedraaid, e.g. ontwikkel omgeving, test omgeving, productie omgeving.
-// In such cases you should document all relevant environments.
 In zulke gevallen moeten alle relevevante omgevingen worden gedocumenteerd.
 
-// Especially document a deployment view if your software is executed as distributed system with more than one computer, processor, server or container or when you design and construct your own hardware processors and chips.
 In het bijzonder als de software wordt uitgevoerd op een gedistribueerd systeem, met meer dan een computer, processor, server of container _of_ als er gebruik wordt gemaakt van zelf ontworpen hardware en/of chips, is het van belang om de deployment view vast te leggen.
 
-// From a software perspective it is sufficient to capture only those elements of an infrastructure that are needed to show a deployment of your building blocks.
 Vanuit een software perspectief is het voldoende om alleen die elementen van de infrastrucuur vast te leggen die nodig zijn om de deployment view van de bouwstenen te tonen.
-// Hardware architects can go beyond that and describe an infrastructure to any level of detail they need to capture.
 Hardware architecten kunnen verder gaan en de infrastruur beschrijven tot het detail niveau dat voor hun passend is.
 
-// .Motivation
 .Motivatie
-// Software does not run without hardware.
 Software draait niet zonder hardware.
-// This underlying infrastructure can and will influence a system and/or some cross-cutting concepts.
 Deze onderliggende infrastructuur heeft invloed om het systeem en/of sommige cross-cutting concepten.
-// Therefore, there is a need to know the infrastructure.
 Daarom is het van belang kennis te hebben van de infrastructuur.
 
-// .Form
 .Vorm
 
-// Maybe a highest level deployment diagram is already contained in section 3.2. as technical context with your own infrastructure as ONE black box. 
 Mogelijk is er op het hoogste niveau al een deployment diagram opgenomen in paragraaf 3.2. als technische context met de eigen infrastructuur als 1 "black box".
 
-// In this section one can zoom into this black box using additional deployment diagrams:
 In deze paragraaf kan worden ingezoomd op deze "black box" met aanvullende deployment diagrammen:
 
-// * UML offers deployment diagrams to express that view.
 * UML bied deployment diagrammen om die view weer te geven.
-// Use it, probably with nested diagrams, when your infrastructure is more complex.
 Gebruik deze, eventueel met geneste diagrammen, als de infrastructuur ingewikkelder is.
-// * When your (hardware) stakeholders prefer other kinds of diagrams rather than a deployment diagram, let them use any kind that is able to show nodes and channels of the infrastructure.
 * Als de (hardware) belanghebbenden er de voorkeur aan geven kunnen ander type diagrammen gebruikt worden.
 Gebruik passende diagrammen om de nodes en kanalen van de infrastructuur weer te geven.
 
 
-// .Further Information
 .Verdere Informatie
 
-// See https://docs.arc42.org/section-7/[Deployment View] in the arc42 documentation.
 Zie https://docs.arc42.org/section-7/[Deployment View] in de arc42 documentatie.
 
 ****
 
-// === Infrastructure Level 1
 === Infrastructuur Niveau 1
 
 [role="arc42help"]
 ****
-// Describe (usually in a combination of diagrams, tables, and text):
 Beschrijf (normaliter in een combinatie van diagrammen, tabellen en text):
 
-// * distribution of a system to multiple locations, environments, computers, processors, .., as well as physical connections between them
 * distributie van het systeem over meerdere locaties, omgevingen, computers, processors, .., als ook de fysieke verbindingen ertussen
-// * important justifications or motivations for this deployment structure
 * verantwoording of motivatie voor deze deployment strucuur
-// * quality and/or performance features of this infrastructure
 * kwaliteit en/of performance attributen van deze infrastructuur
-// * mapping of software artifacts to elements of this infrastructure
 *  mapping van software artifacten naar elementen van deze infrastructuur
 
-// For multiple environments or alternative deployments please copy and adapt this section of arc42 for all relevant environments.
 Als er sprake is van meerdere omgevingen of alternatieve deployments kopieer en pas deze paragraaf van arc42 aan voor alle relevente omgevingen. 
 
 ****
 
-// _**<Overview Diagram>**_
 _**<Overzichts Diagram>**_
 
-// Motivation::
 Motivatie::
 
-// _<explanation in text form>_
 _<uitleg in tekstuele vorm>_
 
-// Quality and/or Performance Features::
 Kwaliteit en/of Performance Eigenschappen::
 
-// _<explanation in text form>_
 _<uitleg in tekstuele vorm>_
 
-// Mapping of Building Blocks to Infrastructure::
-Mapping van Bouwblokken naar Infrastructuur::
-// _<description of the mapping>_
+Mapping van Bouwstenen naar Infrastructuur::
 _<beschrijving van de mapping>_
 
 
-// === Infrastructure Level 2
 === Infrastructuur Niveau 2
 
 [role="arc42help"]
 ****
-// Here you can include the internal structure of (some) infrastructure elements from level 1.
 Hier kunnen de interne structuren van (sommige) infrastructuur elementen uit niveau 1 worden toegevoegd.
 
-// Please copy the structure from level 1 for each selected element.
 Kopieer de structuur van niveau 1 voor ieder geselecteerd element.
 ****
 
-// ==== _<Infrastructure Element 1>_
 ==== _<Infrastructuur Element 1>_
 
-// _<diagram + explanation>_
 _<diagram + uitleg>_
 
-// ==== _<Infrastructure Element 2>_
 ==== _<Infrastructuur Element 2>_
 
-// _<diagram + explanation>_
 _<diagram + uitleg>_
 
 ...
 
-// ==== _<Infrastructure Element n>_
 ==== _<Infrastructuur Element n>_
 
-// _<diagram + explanation>_
 _<diagram + uitleg>_

--- a/NL/asciidoc/src/08_concepts.adoc
+++ b/NL/asciidoc/src/08_concepts.adoc
@@ -1,0 +1,109 @@
+[[section-concepts]]
+// == Cross-cutting Concepts
+== Cross-cutting Concepten
+
+
+[role="arc42help"]
+****
+// .Content
+.Inhoud
+// This section describes overall, principal regulations and solution ideas that are relevant in multiple parts (= cross-cutting) of your system.
+Dit deel beschrijft uitgangspunten en concepten die relevant zijn voor meerdere delen (=cross-cutting) van het systeem.
+// Such concepts are often related to multiple building blocks.
+Dergelijke concepten zijn vaak van toepassing op meerdere bouwstenen.
+// They can include many different topics, such as
+Ze kunnen meerdere onderwerpen beslaan, zoals
+
+// * models, especially domain models
+* modellen, in het bijzonder domein modellen
+// * architecture or design patterns
+* architectuur of design patterns
+// * rules for using specific technology
+* regels om specifiek technologie te gebruiken
+// * principal, often technical decisions of an overarching (= cross-cutting) nature
+* uitgangspunten, vaak technische afspraken van overkoepelende aard (= cross-cutting) aard
+// * implementation rules
+* implementatie regels
+
+
+// .Motivation
+.Motivatie
+// Concepts form the basis for _conceptual integrity_ (consistency, homogeneity) of the architecture. 
+Concepten vormen de basis van _conceptuele integriteit_ (consistentie en homogeniteit) van de architectuur.
+// Thus, they are an important contribution to achieve inner qualities of your system.
+Zodoende vormen ze een belangrijk hulpmiddel om de innerlijke kenmerken van de architectuur vast te leggen.
+
+// Some of these concepts cannot be assigned to individual building blocks, e.g. security or safety. 
+Sommige van deze concepten kunnen niet toegekend worden aan individuele bouwstenen, e.g. security of veiligheid.
+
+// .Form
+.Vorm
+// The form can be varied:
+De vorm kan varieeren:
+
+// * concept papers with any kind of structure
+* concept papers die een structuur beschrijven 
+// * cross-cutting model excerpts or scenarios using notations of the architecture views
+* cross-cutting model uittreksels of scenarios waarbij gebruik wordt gemaakt van architectuur views
+// * sample implementations, especially for technical concepts
+* voorbeeld implementaties, specifiek voor technische concepten
+// * reference to typical usage of standard frameworks (e.g. using Hibernate for object/relational mapping)
+* referenties naar typerend gebruik van standaard frameworks (e.g. Hibernate gebruiken voor object/relational mapping)
+
+// .Structure
+.Structuur
+// A potential (but not mandatory) structure for this section could be:
+Een mogelijke (maar niet verplicht) structuur van deze paragraaf zou kunnen bestaan uit:
+
+// * Domain concepts
+* Domein concepten
+// * User Experience concepts (UX)
+* User Experience concepten (UX)
+// * Safety and security concepts
+* Veiligheid en security concepten
+// * Architecture and design patterns
+* Architectuur en design patterns
+// * "Under-the-hood"
+* "Under-de-motorkap"
+// * development concepts
+* ontwikkel concepten
+// * operational concepts
+* operationele concepten
+
+// Note: it might be difficult to assign individual concepts to one specific topic on this list.
+NOTE: het kan moeilijk zijn om individuele concepten toe te kennen aan een specifiek onderwerp van deze lijst
+
+// image::08-Crosscutting-Concepts-Structure-EN.png["Possible topics for crosscutting concepts"]
+image::08-Crosscutting-Concepts-Structure-EN.png["Mogelijke onderwerpen voor cross-cutting concepten"]
+
+
+
+// .Further Information
+.Verdere informatie
+
+// See https://docs.arc42.org/section-8/[Concepts] in the arc42 documentation.
+Zie https://docs.arc42.org/section-8/[Concepts] in de arc42 documentatie.
+****
+
+
+// === _<Concept 1>_
+=== _<Concept 1>_
+
+// _<explanation>_
+_<uitleg>_
+
+
+
+// === _<Concept 2>_
+=== _<Concept 2>_
+
+// _<explanation>_
+_<uitleg>_
+
+...
+
+// === _<Concept n>_
+=== _<Concept n>_
+
+// _<explanation>_
+_<uitleg>_

--- a/NL/asciidoc/src/08_concepts.adoc
+++ b/NL/asciidoc/src/08_concepts.adoc
@@ -1,109 +1,70 @@
 [[section-concepts]]
-// == Cross-cutting Concepts
 == Cross-cutting Concepten
 
 
 [role="arc42help"]
 ****
-// .Content
 .Inhoud
-// This section describes overall, principal regulations and solution ideas that are relevant in multiple parts (= cross-cutting) of your system.
 Dit deel beschrijft uitgangspunten en concepten die relevant zijn voor meerdere delen (=cross-cutting) van het systeem.
-// Such concepts are often related to multiple building blocks.
 Dergelijke concepten zijn vaak van toepassing op meerdere bouwstenen.
-// They can include many different topics, such as
 Ze kunnen meerdere onderwerpen beslaan, zoals
 
-// * models, especially domain models
 * modellen, in het bijzonder domein modellen
-// * architecture or design patterns
 * architectuur of design patterns
-// * rules for using specific technology
 * regels om specifiek technologie te gebruiken
-// * principal, often technical decisions of an overarching (= cross-cutting) nature
 * uitgangspunten, vaak technische afspraken van overkoepelende aard (= cross-cutting) aard
-// * implementation rules
 * implementatie regels
 
 
-// .Motivation
 .Motivatie
-// Concepts form the basis for _conceptual integrity_ (consistency, homogeneity) of the architecture. 
 Concepten vormen de basis van _conceptuele integriteit_ (consistentie en homogeniteit) van de architectuur.
-// Thus, they are an important contribution to achieve inner qualities of your system.
 Zodoende vormen ze een belangrijk hulpmiddel om de innerlijke kenmerken van de architectuur vast te leggen.
 
-// Some of these concepts cannot be assigned to individual building blocks, e.g. security or safety. 
 Sommige van deze concepten kunnen niet toegekend worden aan individuele bouwstenen, e.g. security of veiligheid.
 
-// .Form
 .Vorm
-// The form can be varied:
 De vorm kan varieeren:
 
-// * concept papers with any kind of structure
 * concept papers die een structuur beschrijven 
-// * cross-cutting model excerpts or scenarios using notations of the architecture views
 * cross-cutting model uittreksels of scenarios waarbij gebruik wordt gemaakt van architectuur views
-// * sample implementations, especially for technical concepts
 * voorbeeld implementaties, specifiek voor technische concepten
-// * reference to typical usage of standard frameworks (e.g. using Hibernate for object/relational mapping)
 * referenties naar typerend gebruik van standaard frameworks (e.g. Hibernate gebruiken voor object/relational mapping)
 
-// .Structure
 .Structuur
-// A potential (but not mandatory) structure for this section could be:
 Een mogelijke (maar niet verplicht) structuur van deze paragraaf zou kunnen bestaan uit:
 
-// * Domain concepts
 * Domein concepten
-// * User Experience concepts (UX)
 * User Experience concepten (UX)
-// * Safety and security concepts
 * Veiligheid en security concepten
-// * Architecture and design patterns
 * Architectuur en design patterns
-// * "Under-the-hood"
 * "Under-de-motorkap"
-// * development concepts
 * ontwikkel concepten
-// * operational concepts
 * operationele concepten
 
-// Note: it might be difficult to assign individual concepts to one specific topic on this list.
 NOTE: het kan moeilijk zijn om individuele concepten toe te kennen aan een specifiek onderwerp van deze lijst
 
-// image::08-Crosscutting-Concepts-Structure-EN.png["Possible topics for crosscutting concepts"]
 image::08-Crosscutting-Concepts-Structure-EN.png["Mogelijke onderwerpen voor cross-cutting concepten"]
 
 
 
-// .Further Information
 .Verdere informatie
 
-// See https://docs.arc42.org/section-8/[Concepts] in the arc42 documentation.
 Zie https://docs.arc42.org/section-8/[Concepts] in de arc42 documentatie.
 ****
 
 
-// === _<Concept 1>_
 === _<Concept 1>_
 
-// _<explanation>_
 _<uitleg>_
 
 
 
-// === _<Concept 2>_
 === _<Concept 2>_
 
-// _<explanation>_
 _<uitleg>_
 
 ...
 
-// === _<Concept n>_
 === _<Concept n>_
 
-// _<explanation>_
 _<uitleg>_

--- a/NL/asciidoc/src/09_architecture_decisions.adoc
+++ b/NL/asciidoc/src/09_architecture_decisions.adoc
@@ -1,0 +1,48 @@
+[[section-design-decisions]]
+// == Architecture Decisions
+== Architectuur Beslissingen
+
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// Important, expensive, large scale or risky architecture decisions including rationals.
+Belangrijke, kostbare, ver reikende of risicovolle beslissingen die betrekking hebben op de architectuur met bijbehorende motivering.
+// With "decisions" we mean selecting one alternative based on given criteria.
+Met "beslissingen" wordt bedoeld dat, op basis van gegeven criteria, een alternatief wordt gekozen.
+
+// Please use your judgement to decide whether an architectural decision should be documented here in this central section or whether you better document it locally (e.g. within the white box template of one building block).
+Beoordeel zelf of de architectuur keuze op deze centrale plek moet worden vastgelegd of in de gespecialiseerde context (bijvoorbeeld binnen een "white box" template van een bouwsteen).
+
+// Avoid redundancy.
+Vermeid doublures.
+// Refer to section 4, where you already captured the most important decisions of your architecture.
+Verwijs naar hoodstuk 4 als daar al belangrijke architectuur beslissingen zijn vastgelegd.
+
+// .Motivation
+.Motivatie
+// Stakeholders of your system should be able to comprehend and retrace your decisions.
+Belanghebbende van het systeem moeten in staat zijn om de gemaakte keuzes te begrijpen en te herleiden.
+
+// .Form
+.Vorm
+// Various options:
+Er zijn verschillende opties:
+
+// * ADR ((https://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions[Architecture Decision Record])) for every important decision
+* ADR ((https://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions[Architecture Decision Record])) voor iedere belangrijke beslissing;
+// * List or table, ordered by importance and consequences or:
+* Lijst of tabel, gesorteerd op belang en consequenties of;
+// * more detailed in form of separate sections per decision
+* meer gedetaileerd in de vorm van een paragraaf per gemaakte beslissing
+
+// .Further Information
+.Verdere Informatie
+
+// See https://docs.arc42.org/section-9/[Architecture Decisions] in the arc42 documentation.
+Zie https://docs.arc42.org/section-9/[Architecture Decisions] in de arc42 documentatie.
+// There you will find links and examples about ADR.
+Daar zijn ook links en voorbeelden van een ADR te vinden.
+
+****

--- a/NL/asciidoc/src/09_architecture_decisions.adoc
+++ b/NL/asciidoc/src/09_architecture_decisions.adoc
@@ -1,48 +1,31 @@
 [[section-design-decisions]]
-// == Architecture Decisions
 == Architectuur Beslissingen
 
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// Important, expensive, large scale or risky architecture decisions including rationals.
 Belangrijke, kostbare, ver reikende of risicovolle beslissingen die betrekking hebben op de architectuur met bijbehorende motivering.
-// With "decisions" we mean selecting one alternative based on given criteria.
 Met "beslissingen" wordt bedoeld dat, op basis van gegeven criteria, een alternatief wordt gekozen.
 
-// Please use your judgement to decide whether an architectural decision should be documented here in this central section or whether you better document it locally (e.g. within the white box template of one building block).
 Beoordeel zelf of de architectuur keuze op deze centrale plek moet worden vastgelegd of in de gespecialiseerde context (bijvoorbeeld binnen een "white box" template van een bouwsteen).
 
-// Avoid redundancy.
-Vermeid doublures.
-// Refer to section 4, where you already captured the most important decisions of your architecture.
+Vermijd doublures.
 Verwijs naar hoodstuk 4 als daar al belangrijke architectuur beslissingen zijn vastgelegd.
 
-// .Motivation
 .Motivatie
-// Stakeholders of your system should be able to comprehend and retrace your decisions.
 Belanghebbende van het systeem moeten in staat zijn om de gemaakte keuzes te begrijpen en te herleiden.
 
-// .Form
 .Vorm
-// Various options:
 Er zijn verschillende opties:
 
-// * ADR ((https://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions[Architecture Decision Record])) for every important decision
 * ADR ((https://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions[Architecture Decision Record])) voor iedere belangrijke beslissing;
-// * List or table, ordered by importance and consequences or:
 * Lijst of tabel, gesorteerd op belang en consequenties of;
-// * more detailed in form of separate sections per decision
 * meer gedetaileerd in de vorm van een paragraaf per gemaakte beslissing
 
-// .Further Information
 .Verdere Informatie
 
-// See https://docs.arc42.org/section-9/[Architecture Decisions] in the arc42 documentation.
 Zie https://docs.arc42.org/section-9/[Architecture Decisions] in de arc42 documentatie.
-// There you will find links and examples about ADR.
 Daar zijn ook links en voorbeelden van een ADR te vinden.
 
 ****

--- a/NL/asciidoc/src/10_quality_requirements.adoc
+++ b/NL/asciidoc/src/10_quality_requirements.adoc
@@ -1,0 +1,105 @@
+[[section-quality-scenarios]]
+// == Quality Requirements
+== Kwaliteits Requirements
+
+
+[role="arc42help"]
+****
+
+// .Content
+.Inhoud
+// This section contains all quality requirements as quality tree with scenarios.
+Dit hoofdstuk bevat alle kwaliteits requirements als een kwaliteits boom met scenarios.
+// The most important ones have already been described in section 1.2. (quality goals)
+De belangrijkste zijn al beschreven in paragraaf 1.2 (kwaliteits doelen.)
+
+// Here you can also capture quality requirements with lesser priority, which will not create high risks when they are not fully achieved.
+Op deze plaats kunnen ook lagere prioriteit kwaliteits requirements worden vastgelegd die, als ze niet (volledig) worden gerealiseerd, geen hoog risico vormen.
+
+// .Motivation
+.Motivatie
+// Since quality requirements will have a lot of influence on architectural decisions you should know for every stakeholder what is really important to them, concrete and measurable.
+Omdat kwaliteits requirements grote invloed invloed hebben op architectuur beslissingen is het van belang om voor iedere belanghebbende, in concrete en meetbare termen, te begrijpen wat echt van belang is. 
+
+
+// .Further Information
+.Verdere Informatie
+
+// See https://docs.arc42.org/section-10/[Quality Requirements] in the arc42 documentation.
+Zie https://docs.arc42.org/section-10/[Quality Requirements] in de arc42 documentatie.
+
+****
+
+// === Quality Tree
+=== Kwaliteits Boom
+
+[role="arc42help"]
+****
+// .Content
+.Inhoud
+// The quality tree (as defined in ATAM - Architecture Tradeoff Analysis Method) with quality/evaluation scenarios as leafs.
+De kwaliteits boom (zoals gedefinieerd in ATAM - Architecture Analysis Method) met kwaliteit/evaluatie scenarios als bladeren.
+
+// .Motivation
+.Motivatie
+// The tree structure with priorities provides an overview for a sometimes large number of quality requirements.
+De geprioriteerde boomstructuur bied overzicht over, een mogelijk groot aantal, kwaliteits requirements.
+
+// .Form
+.Vorm
+// The quality tree is a high-level overview of the quality goals and requirements:
+De kwaliteitsboom is een hoog niveau overzicht van de kwaliteits doelen en requirements:
+
+// * tree-like refinement of the term "quality".
+* verdieping van de term "kwaliteit" in de vorm van een boom structuur
+// Use "quality" or "usefulness" as a root
+Gebruik daarbij "kwaliteit" als de root van de boom.
+// * a mind map with quality categories as main branches
+* een mind map met kwaliteit categorieen als eerste takken
+
+// In any case the tree should include links to the scenarios of the following section.
+De boom moet in elk geval verwijzingen/links bevatten naar de scenarios in de volgende paragraaf.
+
+
+****
+
+// === Quality Scenarios
+=== Kwaliteits Scenarios
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// Concretization of (sometimes vague or implicit) quality requirements using (quality) scenarios.
+Het concreet maken van (soms vage of impliciete) kwaliteits requirements gebruik makend van (kwaliteits) scenarios.
+
+// These scenarios describe what should happen when a stimulus arrives at the system.
+Deze scenarios beschrijven wat er moet gebeuren als het systeem wordt geconfronteerd met een stimulus.
+
+// For architects, two kinds of scenarios are important:
+Voor architecten zijn er twee soorten scenarios van belang:
+
+// * Usage scenarios (also called application scenarios or use case scenarios) describe the system’s runtime reaction to a certain stimulus.
+* Gebruik scenarios (ook wel applicatie scenarios of use case scenarios genoemd) beschrijven het runtime gedrag van het systeem naar aanleiding van een bepaalde stimulus.
+// This also includes scenarios that describe the system’s efficiency or performance.
+Dit is inclusief scenarios die de efficientie of performance van het systeem beschrijven.
+// Example: The system reacts to a user’s request within one second.
+Bijvoorbeeld: Het systeem reageert binnen een seconde op een request.
+// * Change scenarios describe a modification of the system or of its immediate environment.
+* Verander scenarios beschrijven modificaties aan het systeem, of aan haar onmiddelijke omgeving
+// Example: Additional functionality is implemented or requirements for a quality attribute change.
+Bijvoorbeeld: Er moet aanvullende functionaliteit geimplementeerd worden of de eis voor een kwaliteitskenmerk verandert.
+
+// .Motivation
+.Motivatie
+// Scenarios make quality requirements concrete and allow to more easily measure or decide whether they are fulfilled.
+Scenarios maken kwaliteits requirements concreet en maken het daarmee eenvoudiger om te meten of te bepalen of ze vervuld worden.
+
+// Especially when you want to assess your architecture using methods like ATAM you need to describe your quality goals (from section 1.2) more precisely down to a level of scenarios that can be discussed and evaluated.
+Vooral als er methodes als ATAM worden gebruikt is het van belang om de kwaliteits doelen (uit paragraaf 1.2) tot op het niveau van scenarios die besproken en bediscussieerd kunnen worden, te beschrijven.
+
+// .Form
+.Vorm
+// Tabular or free form text.
+Lijst of vrije tekst vorm.
+****

--- a/NL/asciidoc/src/10_quality_requirements.adoc
+++ b/NL/asciidoc/src/10_quality_requirements.adoc
@@ -1,105 +1,70 @@
 [[section-quality-scenarios]]
-// == Quality Requirements
 == Kwaliteits Requirements
 
 
 [role="arc42help"]
 ****
 
-// .Content
 .Inhoud
-// This section contains all quality requirements as quality tree with scenarios.
 Dit hoofdstuk bevat alle kwaliteits requirements als een kwaliteits boom met scenarios.
-// The most important ones have already been described in section 1.2. (quality goals)
 De belangrijkste zijn al beschreven in paragraaf 1.2 (kwaliteits doelen.)
 
-// Here you can also capture quality requirements with lesser priority, which will not create high risks when they are not fully achieved.
 Op deze plaats kunnen ook lagere prioriteit kwaliteits requirements worden vastgelegd die, als ze niet (volledig) worden gerealiseerd, geen hoog risico vormen.
 
-// .Motivation
 .Motivatie
-// Since quality requirements will have a lot of influence on architectural decisions you should know for every stakeholder what is really important to them, concrete and measurable.
 Omdat kwaliteits requirements grote invloed invloed hebben op architectuur beslissingen is het van belang om voor iedere belanghebbende, in concrete en meetbare termen, te begrijpen wat echt van belang is. 
 
 
-// .Further Information
 .Verdere Informatie
 
-// See https://docs.arc42.org/section-10/[Quality Requirements] in the arc42 documentation.
 Zie https://docs.arc42.org/section-10/[Quality Requirements] in de arc42 documentatie.
 
 ****
 
-// === Quality Tree
 === Kwaliteits Boom
 
 [role="arc42help"]
 ****
-// .Content
 .Inhoud
-// The quality tree (as defined in ATAM - Architecture Tradeoff Analysis Method) with quality/evaluation scenarios as leafs.
 De kwaliteits boom (zoals gedefinieerd in ATAM - Architecture Analysis Method) met kwaliteit/evaluatie scenarios als bladeren.
 
-// .Motivation
 .Motivatie
-// The tree structure with priorities provides an overview for a sometimes large number of quality requirements.
 De geprioriteerde boomstructuur bied overzicht over, een mogelijk groot aantal, kwaliteits requirements.
 
-// .Form
 .Vorm
-// The quality tree is a high-level overview of the quality goals and requirements:
 De kwaliteitsboom is een hoog niveau overzicht van de kwaliteits doelen en requirements:
 
-// * tree-like refinement of the term "quality".
 * verdieping van de term "kwaliteit" in de vorm van een boom structuur
-// Use "quality" or "usefulness" as a root
 Gebruik daarbij "kwaliteit" als de root van de boom.
-// * a mind map with quality categories as main branches
 * een mind map met kwaliteit categorieen als eerste takken
 
-// In any case the tree should include links to the scenarios of the following section.
 De boom moet in elk geval verwijzingen/links bevatten naar de scenarios in de volgende paragraaf.
 
 
 ****
 
-// === Quality Scenarios
 === Kwaliteits Scenarios
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// Concretization of (sometimes vague or implicit) quality requirements using (quality) scenarios.
 Het concreet maken van (soms vage of impliciete) kwaliteits requirements gebruik makend van (kwaliteits) scenarios.
 
-// These scenarios describe what should happen when a stimulus arrives at the system.
 Deze scenarios beschrijven wat er moet gebeuren als het systeem wordt geconfronteerd met een stimulus.
 
-// For architects, two kinds of scenarios are important:
 Voor architecten zijn er twee soorten scenarios van belang:
 
-// * Usage scenarios (also called application scenarios or use case scenarios) describe the system’s runtime reaction to a certain stimulus.
 * Gebruik scenarios (ook wel applicatie scenarios of use case scenarios genoemd) beschrijven het runtime gedrag van het systeem naar aanleiding van een bepaalde stimulus.
-// This also includes scenarios that describe the system’s efficiency or performance.
 Dit is inclusief scenarios die de efficientie of performance van het systeem beschrijven.
-// Example: The system reacts to a user’s request within one second.
 Bijvoorbeeld: Het systeem reageert binnen een seconde op een request.
-// * Change scenarios describe a modification of the system or of its immediate environment.
 * Verander scenarios beschrijven modificaties aan het systeem, of aan haar onmiddelijke omgeving
-// Example: Additional functionality is implemented or requirements for a quality attribute change.
 Bijvoorbeeld: Er moet aanvullende functionaliteit geimplementeerd worden of de eis voor een kwaliteitskenmerk verandert.
 
-// .Motivation
 .Motivatie
-// Scenarios make quality requirements concrete and allow to more easily measure or decide whether they are fulfilled.
 Scenarios maken kwaliteits requirements concreet en maken het daarmee eenvoudiger om te meten of te bepalen of ze vervuld worden.
 
-// Especially when you want to assess your architecture using methods like ATAM you need to describe your quality goals (from section 1.2) more precisely down to a level of scenarios that can be discussed and evaluated.
 Vooral als er methodes als ATAM worden gebruikt is het van belang om de kwaliteits doelen (uit paragraaf 1.2) tot op het niveau van scenarios die besproken en bediscussieerd kunnen worden, te beschrijven.
 
-// .Form
 .Vorm
-// Tabular or free form text.
 Lijst of vrije tekst vorm.
 ****

--- a/NL/asciidoc/src/11_technical_risks.adoc
+++ b/NL/asciidoc/src/11_technical_risks.adoc
@@ -1,0 +1,33 @@
+[[section-technical-risks]]
+// == Risks and Technical Debts
+== Risico's en Technical Debt
+
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// A list of identified technical risks or technical debts, ordered by priority
+Een op prioriteit gesorteerde lijst, met bekende technische risico's en technical dept.
+
+// .Motivation
+.Motivatie
+// “Risk management is project management for grown-ups” (Tim Lister, Atlantic Systems Guild.)
+“Risk management is project management for grown-ups” (Tim Lister, Atlantic Systems Guild.)
+
+// This should be your motto for systematic detection and evaluation of risks and technical debts in the architecture, which will be needed by management stakeholders (e.g. project managers, product owners) as part of the overall risk analysis and measurement planning.
+Dit zou het motto moeten zijn bij het systematisch bepalen en evalueren van risico's en technical dept in de architectuur.
+Management stakeholder (bijvoorbeeld project managers of project owners) hebben dit inzicht nodig om keuzes te kunnen maken met betrekking tot risico en planning.
+
+// .Form
+.Vorm
+// List of risks and/or technical debts, probably including suggested measures to minimize, mitigate or avoid risks or reduce technical debts.
+Lijst van risico's en/of technical dept eventueel aangevuld met maatregelen om deze te minimaliseren, verzachten of te vermijden.
+
+// .Further Information
+.Verdere Informatie
+
+// See https://docs.arc42.org/section-11/[Risks and Technical Debt] in the arc42 documentation.
+Zie https://docs.arc42.org/section-11/[Risks and Technical Debt] in de arc42 documentatie.
+
+****

--- a/NL/asciidoc/src/11_technical_risks.adoc
+++ b/NL/asciidoc/src/11_technical_risks.adoc
@@ -1,33 +1,23 @@
 [[section-technical-risks]]
-// == Risks and Technical Debts
 == Risico's en Technical Debt
 
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// A list of identified technical risks or technical debts, ordered by priority
 Een op prioriteit gesorteerde lijst, met bekende technische risico's en technical dept.
 
-// .Motivation
 .Motivatie
-// “Risk management is project management for grown-ups” (Tim Lister, Atlantic Systems Guild.)
 “Risk management is project management for grown-ups” (Tim Lister, Atlantic Systems Guild.)
 
-// This should be your motto for systematic detection and evaluation of risks and technical debts in the architecture, which will be needed by management stakeholders (e.g. project managers, product owners) as part of the overall risk analysis and measurement planning.
 Dit zou het motto moeten zijn bij het systematisch bepalen en evalueren van risico's en technical dept in de architectuur.
 Management stakeholder (bijvoorbeeld project managers of project owners) hebben dit inzicht nodig om keuzes te kunnen maken met betrekking tot risico en planning.
 
-// .Form
 .Vorm
-// List of risks and/or technical debts, probably including suggested measures to minimize, mitigate or avoid risks or reduce technical debts.
 Lijst van risico's en/of technical dept eventueel aangevuld met maatregelen om deze te minimaliseren, verzachten of te vermijden.
 
-// .Further Information
 .Verdere Informatie
 
-// See https://docs.arc42.org/section-11/[Risks and Technical Debt] in the arc42 documentation.
 Zie https://docs.arc42.org/section-11/[Risks and Technical Debt] in de arc42 documentatie.
 
 ****

--- a/NL/asciidoc/src/12_glossary.adoc
+++ b/NL/asciidoc/src/12_glossary.adoc
@@ -1,0 +1,55 @@
+[[section-glossary]]
+// == Glossary
+== Woordenlijst
+
+[role="arc42help"]
+****
+// .Contents
+.Inhoud
+// The most important domain and technical terms that your stakeholders use when discussing the system.
+De belangrijkste domein en technische termen die belanghebbenden gebruiken tijdens het bespreken van het systeem.
+
+// You can also see the glossary as source for translations if you work in multi-language teams.
+De woordenlijst kan ook als bron voor vertaalde termen worden gebruikt bij meertalige teams.
+
+// .Motivation
+.Motivatie
+// You should clearly define your terms, so that all stakeholders
+Termen moeten helder worden gedefinieerd zodat alle belanghebbenden
+
+// * have an identical understanding of these terms
+* een gemeenschappelijk en eenduidig begrip hebben van deze termen
+// * do not use synonyms and homonyms
+* geen gebruik maken van synoniemen of homoniemen
+
+// .Form
+.Vorm
+// * A table with columns <Term> and <Definition>.
+* Een tabel met kolommen <Term> en <Definitie>.
+// * Potentially more columns in case you need translations.
+* Eventueel meerdere kolommen als er vertalingen nodig zijn.
+
+
+// .Further Information
+.Verdere Informatie
+
+// See https://docs.arc42.org/section-12/[Glossary] in the arc42 documentation.
+See https://docs.arc42.org/section-12/[Glossary] in the arc42 documentation.
+
+****
+
+[cols="e,2e" options="header"]
+|===
+// |Term |Definition
+| Term | Definitie
+
+// |<Term-1>
+// |<definition-1>
+| <Term-1>
+| <definitie-1>
+
+// |<Term-2>
+// |<definition-2>
+| <Term-2>
+| <definitie-2>
+|===

--- a/NL/asciidoc/src/12_glossary.adoc
+++ b/NL/asciidoc/src/12_glossary.adoc
@@ -1,55 +1,37 @@
 [[section-glossary]]
-// == Glossary
 == Woordenlijst
 
 [role="arc42help"]
 ****
-// .Contents
 .Inhoud
-// The most important domain and technical terms that your stakeholders use when discussing the system.
 De belangrijkste domein en technische termen die belanghebbenden gebruiken tijdens het bespreken van het systeem.
 
-// You can also see the glossary as source for translations if you work in multi-language teams.
 De woordenlijst kan ook als bron voor vertaalde termen worden gebruikt bij meertalige teams.
 
-// .Motivation
 .Motivatie
-// You should clearly define your terms, so that all stakeholders
 Termen moeten helder worden gedefinieerd zodat alle belanghebbenden
 
-// * have an identical understanding of these terms
 * een gemeenschappelijk en eenduidig begrip hebben van deze termen
-// * do not use synonyms and homonyms
 * geen gebruik maken van synoniemen of homoniemen
 
-// .Form
 .Vorm
-// * A table with columns <Term> and <Definition>.
 * Een tabel met kolommen <Term> en <Definitie>.
-// * Potentially more columns in case you need translations.
 * Eventueel meerdere kolommen als er vertalingen nodig zijn.
 
 
-// .Further Information
 .Verdere Informatie
 
-// See https://docs.arc42.org/section-12/[Glossary] in the arc42 documentation.
 See https://docs.arc42.org/section-12/[Glossary] in the arc42 documentation.
 
 ****
 
 [cols="e,2e" options="header"]
 |===
-// |Term |Definition
 | Term | Definitie
 
-// |<Term-1>
-// |<definition-1>
 | <Term-1>
 | <definitie-1>
 
-// |<Term-2>
-// |<definition-2>
 | <Term-2>
 | <definitie-2>
 |===

--- a/NL/asciidoc/src/about-arc42.adoc
+++ b/NL/asciidoc/src/about-arc42.adoc
@@ -1,0 +1,21 @@
+:homepage: https://arc42.org
+
+:keywords: software-architecture, documentation, template, arc42
+
+:numbered!:
+// **About arc42**
+**Over arc42**
+
+[role="lead"]
+// arc42, the Template for documentation of software and system architecture.
+arc42, de Template voor documentatie van software en systeem architectuur.
+
+// Created and maintained by Dr. Peter Hruschka, Dr. Gernot Starke and contributors.
+Gecreeerd en onderhouden door Dr. Peter Hruschka, Dr. Gernot Starke en bijdragers.
+
+// Template Revision: 8.0 EN (based on asciidoc), February 2022
+Template Revisie: 8.0 NL (based on asciidoc), February 2022
+
+(C)
+// We acknowledge that this document uses material from the arc 42 architecture template, https://arc42.org.
+We erkennen dat dit document materiaal gebruikt van de arc 42 architectuur template, https://arc42.org.

--- a/NL/asciidoc/src/about-arc42.adoc
+++ b/NL/asciidoc/src/about-arc42.adoc
@@ -3,19 +3,14 @@
 :keywords: software-architecture, documentation, template, arc42
 
 :numbered!:
-// **About arc42**
 **Over arc42**
 
 [role="lead"]
-// arc42, the Template for documentation of software and system architecture.
 arc42, de Template voor documentatie van software en systeem architectuur.
 
-// Created and maintained by Dr. Peter Hruschka, Dr. Gernot Starke and contributors.
 Gecreeerd en onderhouden door Dr. Peter Hruschka, Dr. Gernot Starke en bijdragers.
 
-// Template Revision: 8.0 EN (based on asciidoc), February 2022
 Template Revisie: 8.0 NL (based on asciidoc), February 2022
 
 (C)
-// We acknowledge that this document uses material from the arc 42 architecture template, https://arc42.org.
 We erkennen dat dit document materiaal gebruikt van de arc 42 architectuur template, https://arc42.org.

--- a/NL/asciidoc/src/config.adoc
+++ b/NL/asciidoc/src/config.adoc
@@ -1,0 +1,9 @@
+// asciidoc settings for NL (Nederlands)
+// ==================================
+:toc-title: inhoudsopgave
+
+// enable table-of-contents
+:toc:
+
+// where are images located?
+:imagesdir: ./images

--- a/NL/asciidoc/src/termen.adoc
+++ b/NL/asciidoc/src/termen.adoc
@@ -1,0 +1,18 @@
+
+.Vertalingen
+
+|===
+| EN term | NL term
+
+| Abstract | Beschrijving
+| Building block | Bouwsteen
+| Constraints | Beperkingen
+| Channel | Kanaal
+| Excerpt(s) | Uittreksel(s)
+| Extract | Samenvatting
+| Feature | Eigenschap
+| Key quality goals | Meest balangrijke kwaliteits doelen
+| Level | Niveau
+| Stakeholder(s) | Belanghebbende(n)
+
+|===


### PR DESCRIPTION
This pull request is made up of two commits
1. add the translation keeping the English source text as comment
2. remove the commented out English source

All template files have been translated to Dutch using the English documentation as source.

Some English terms haven't been translated since most Dutch engineers will use the English term already, so forcibly translating those terms would hamper acceptance.

A new document has been added (`NL/asciidoc/src/termen.adoc`) containing a dictionary for specific words/terms in order to be able to make a consistent translation of those terms.