### PR TITLE
Be explicit on the source of the translation

### DIFF
--- a/NL/asciidoc/arc42-template.adoc
+++ b/NL/asciidoc/arc42-template.adoc
@@ -4,6 +4,10 @@
 // ====================================
 
 = image:arc42-logo.png[arc42] Template
+:author: Dr. Peter Hruschka, Dr. Gernot Starke en bijdragers
+:revnumber: 8
+:revdate: februari 2022
+:revremark: De NL versie is gebaseerd op EN template versie {revnumber}
 // toc-title definition MUST follow document title without blank line!
 :toc-title: Inhoudsopgave
 

--- a/NL/asciidoc/src/about-arc42.adoc
+++ b/NL/asciidoc/src/about-arc42.adoc
@@ -8,9 +8,9 @@
 [role="lead"]
 arc42, de Template voor documentatie van software en systeem architectuur.
 
-Gecreeerd en onderhouden door Dr. Peter Hruschka, Dr. Gernot Starke en bijdragers.
+Gecreeerd en onderhouden door {author}.
 
-Template Revisie: 8.0 NL (based on asciidoc), February 2022
+Template Versie: {revnumber}. {revremark}, {revdate}
 
 (C)
 We erkennen dat dit document materiaal gebruikt van de arc 42 architectuur template, https://arc42.org.


### PR DESCRIPTION
This pull request goes with issue #156 

Explicitly denote what original document (langauage and version)
the translation is based upon.

Other changes:
* set vars for author, version and notes on the version
* for NL translation change "Revisie" into "Versie" to indicate template version

The line directlty below the document title contains the authors
(separated with a semicolon (;). The problem when explicitly using
multiple authors (separated with the formentioned semilocon), is that
each author will have it's own `author` variable (e.g. `author`,
`author_1`, `author_2`, `author_n`).

In my opinion this defies the purpose of using variable since one
still needs to know how many authors have contributed to the
document when listing all authors.

As such I've choosen to use the author variable to explicitly hold
all authors and contributers.