### PR TITLE
{DE,EN,NL,UA}/asciidoc/src/09*: fix URL

### DIFF
--- a/DE/asciidoc/src/09_architecture_decisions.adoc
+++ b/DE/asciidoc/src/09_architecture_decisions.adoc
@@ -17,7 +17,7 @@ Stakeholder des Systems sollten wichtige Entscheidungen verstehen und nachvollzi
 .Form
 Verschiedene Möglichkeiten:
 
-* ADR (https://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions[Architecture Decision Record]) für jede wichtige Entscheidung
+* ADR (https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions[Documenting Architecture Decisions]) für jede wichtige Entscheidung
 * Liste oder Tabelle, nach Wichtigkeit und Tragweite der Entscheidungen geordnet
 * ausführlicher in Form einzelner Unterkapitel je Entscheidung
 

--- a/EN/asciidoc/src/09_architecture_decisions.adoc
+++ b/EN/asciidoc/src/09_architecture_decisions.adoc
@@ -21,7 +21,7 @@ Stakeholders of your system should be able to comprehend and retrace your decisi
 .Form
 Various options:
 
-* ADR ((https://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions[Architecture Decision Record])) for every important decision
+* ADR (https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions[Documenting Architecture Decisions]) for every important decision
 * List or table, ordered by importance and consequences or:
 * more detailed in form of separate sections per decision
 

--- a/NL/asciidoc/src/09_architecture_decisions.adoc
+++ b/NL/asciidoc/src/09_architecture_decisions.adoc
@@ -19,7 +19,7 @@ Belanghebbende van het systeem moeten in staat zijn om de gemaakte keuzes te beg
 .Vorm
 Er zijn verschillende opties:
 
-* ADR ((https://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions[Architecture Decision Record])) voor iedere belangrijke beslissing;
+* ADR (https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions[Documenting Architecture Decisions]) voor iedere belangrijke beslissing;
 * Lijst of tabel, gesorteerd op belang en consequenties of;
 * meer gedetaileerd in de vorm van een paragraaf per gemaakte beslissing
 

--- a/UA/asciidoc/src/09_architecture_decisions.adoc
+++ b/UA/asciidoc/src/09_architecture_decisions.adoc
@@ -21,7 +21,7 @@
 .Форма
 Різні варіанти:
 
-* ADR ((https://thinkrelevance.com/blog/2011/11/15/documenting-architecture-decisions[Запис архітектурних рішень])) для кожного важливого рішення
+* ADR (https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions[Documenting Architecture Decisions]) для кожного важливого рішення
 * Список або таблиця, упорядкована за важливістю та наслідками або:
 * детальніше у вигляді окремого розділу на кожне рішення
 


### PR DESCRIPTION
Fix URL and caption for blog post of Michael Nygard, since thinkrelevance.com
moved to cognitect.com.

Signed-off-by: Jens Rehsack <sno@netbsd.org>