### PR TITLE
Add example stakeholder table to EN Section 1 (Introduction and Goals)

### DIFF
--- a/EN/adoc/01_introduction_and_goals.adoc
+++ b/EN/adoc/01_introduction_and_goals.adoc
@@ -90,6 +90,24 @@ These stakeholders determine the extent and the level of detail of your work and
 
 .Form
 Table with role names, person names, and their expectations with respect to the architecture and its documentation.
+
+.Example
+The following stakeholder roles recur across most software projects. Use it as a
+starting point, then adapt the roles, names and expectations to your actual project
+-- not every project has all of these roles, and some will have additional ones.
+
+[options="header",cols="1,2,2"]
+|===
+|Role/Name|Contact|Expectations
+|Product Owner|Product Management|Prioritizes features by business value; needs Section 1 (Requirements Overview, Quality Goals) kept aligned with product strategy
+|End Users / Customers|represented via UX research, support tickets|Need the system to be usable, reliable and fast; drive quality goals such as performance and usability
+|Software Architect(s)|Architecture Team|Own and maintain this documentation; use it to justify and communicate technical decisions
+|Development Team|Engineering Team|Need clear building blocks (Section 5) and runtime scenarios (Section 6) to implement correctly
+|Operations / SRE|Ops Team|Need the deployment view (Section 7) and cross-cutting concepts (Section 8, e.g. monitoring, logging) to run the system reliably
+|Security Officer / InfoSec|Security Team|Review the architecture against risks (Section 11) and quality requirements (Section 10); need evidence that security constraints are addressed
+|Compliance / Legal|Legal/Compliance Team|Need evidence that regulatory constraints (Section 2) are respected, e.g. data protection, licensing
+|Project Sponsor / Management|Steering Committee|Need confidence that architecture decisions (Section 9) support budget, timeline and strategic goals
+|===
 ****
 endif::arc42help[]
 


### PR DESCRIPTION
Closes #198.

## Problem

The Stakeholders subsection's only table is the bare placeholder (`<Role-1>`, `<Contact-1>`, `<Expectation-1>`, one more blank row). Someone filling out the template for the first time has no sense of what a *reasonable, filled-in* version looks like, or which roles typically show up on a real project.

## Change

Added a worked example table inside the existing `arc42help` block, right after the existing `.Form` description — same convention already used for `.Motivation`/`.Form` elsewhere in this file, so it only appears in the "with help" template variant and doesn't touch the blank fillable table real projects start from.

The example lists roles that recur across most software projects (Product Owner, End Users, Architects, Dev Team, Ops/SRE, Security/InfoSec, Compliance/Legal, Sponsor/Management), each cross-referenced to the arc42 section their expectations map to (e.g. Ops needs Section 7 deployment view + Section 8 cross-cutting concepts). I checked docs.arc42.org's own Section 1 guidance first — it doesn't currently include an example table either, so this isn't duplicating existing content.

## Verification

Built both output formats locally via `./gradlew -Planguages=EN`:
- HTML: `arc42-template-EN.html` — table renders correctly, "Example" appears as a proper block title matching the existing Motivation/Form styling (confirmed no raw AsciiDoc syntax leaked into output).
- PDF: `arc42-template-EN.pdf` — builds cleanly, 944 KB output.
- `validateImagesEN` task passed (unaffected by this change, but confirms the build overall is healthy against my branch).

## Disclosure

I used AI assistance (Claude) to research this issue, draft the stakeholder list/wording, and verify the build. I reviewed and take responsibility for the content. Happy to adjust roles/wording/scope if you'd prefer a different set or format.